### PR TITLE
Fix network mismatch error for mew

### DIFF
--- a/src/components/TxConfirmationView/NetworkMismatch/index.tsx
+++ b/src/components/TxConfirmationView/NetworkMismatch/index.tsx
@@ -82,7 +82,7 @@ export default function NetworkMismatch({
   //   !isMetaMaskForMatic && ['browser', 'wallet-connect'].includes(currentProviderName);
   const isManualNetworkUpdateNeeded = ['torus', 'portis'].includes(currentProviderName);
   const isNeededNetworkNotSupported =
-    // neededNetworkName === Network.polygon &&
+    neededNetworkName !== Network.mainnet &&
     ['authereum', 'fortmatic', 'mew-wallet', 'ledger', 'gnosis-safe'].includes(currentProviderName);
 
   return (


### PR DESCRIPTION
In some edge cases, user can run MEW not on the main network during connection time, and without this PR user will see that mainnet is not allowed