### PR TITLE
feat: show optimal path

### DIFF
--- a/src/modules/asset-swap/screens/AssetSwapConfirmation/index.tsx
+++ b/src/modules/asset-swap/screens/AssetSwapConfirmation/index.tsx
@@ -27,9 +27,11 @@ interface QueryParams {
   fromAsset?: string;
   toAsset?: string;
   fromAmount?: string;
-  toAmount?: string;
   fromAmountInUSD?: string;
+  toAmount?: string;
   toAmountInUSD?: string;
+  toAmountAfterSlippage?: string;
+  toAmountInUSDAfterSlippage?: string;
   maxSlippage?: string;
   isReverse?: string;
   swapAll?: string;
@@ -52,10 +54,14 @@ export default function AssetSwapConfirmation() {
   const toAsset = query.toAsset;
 
   const fromAmountQuery = valueToBigNumber(query.fromAmount || 0);
-  const toAmountQuery = valueToBigNumber(query.toAmount || 0);
-
   const fromAmountUsdQuery = valueToBigNumber(query.fromAmountInUSD || 0);
+
+  const toAmountQuery = valueToBigNumber(query.toAmount || 0);
   const toAmountUsdQuery = valueToBigNumber(query.toAmountInUSD || 0);
+
+  // TODO: display as separate line as minimum received
+  const toAmountAfterSlippageQuery = valueToBigNumber(query.toAmountAfterSlippage || 0);
+  const toAmountUsdAfterSlippageQuery = valueToBigNumber(query.toAmountInUSDAfterSlippage || 0);
 
   const maxSlippage = valueToBigNumber(query.maxSlippage || 0);
   const totalFees = valueToBigNumber(query.totalFees || 0);
@@ -105,7 +111,7 @@ export default function AssetSwapConfirmation() {
     !fromAsset ||
     !toAsset ||
     !fromAmountQuery.gt(0) ||
-    !toAmountQuery.gt(0) ||
+    !toAmountAfterSlippageQuery.gt(0) ||
     !maxSlippage.gte(0) ||
     !fromPoolReserve ||
     !toPoolReserve
@@ -117,7 +123,7 @@ export default function AssetSwapConfirmation() {
     fromAmountQuery,
     fromPoolReserve,
     fromUserReserve,
-    toAmountQuery,
+    toAmountAfterSlippageQuery,
     toPoolReserve,
     toUserReserve,
     user,
@@ -152,7 +158,7 @@ export default function AssetSwapConfirmation() {
       swapAll,
       fromAToken: fromPoolReserve.aTokenAddress,
       fromAmount: inputAmount.toString(),
-      minToAmount: toAmountQuery.toString(),
+      minToAmount: toAmountAfterSlippageQuery.toString(),
       user: user.id,
       flash:
         user.healthFactor !== '-1' &&
@@ -162,8 +168,8 @@ export default function AssetSwapConfirmation() {
     });
   };
 
-  const currentSlippage = calcToAmount.lt(toAmountQuery)
-    ? toAmountQuery.minus(calcToAmount).div(toAmountQuery)
+  const currentSlippage = calcToAmount.lt(toAmountAfterSlippageQuery)
+    ? toAmountAfterSlippageQuery.minus(calcToAmount).div(toAmountAfterSlippageQuery)
     : valueToBigNumber('0');
 
   if (currentSlippage.gt(maxSlippage)) {
@@ -215,6 +221,16 @@ export default function AssetSwapConfirmation() {
         <Value
           value={toAmountQuery.toNumber()}
           subValue={toAmountUsdQuery.toString()}
+          symbol={toPoolReserve.symbol}
+          subSymbol="USD"
+          tokenIcon={true}
+          tooltipId={toPoolReserve.symbol}
+        />
+      </Row>
+      <Row title={intl.formatMessage(messages.minReceivedTitle)} withMargin={true}>
+        <Value
+          value={toAmountAfterSlippageQuery.toNumber()}
+          subValue={toAmountUsdAfterSlippageQuery.toString()}
           symbol={toPoolReserve.symbol}
           subSymbol="USD"
           tokenIcon={true}

--- a/src/modules/asset-swap/screens/AssetSwapConfirmation/messages.ts
+++ b/src/modules/asset-swap/screens/AssetSwapConfirmation/messages.ts
@@ -10,10 +10,11 @@ export default defineMessages({
 
   fromTitle: 'From asset',
   toTitle: 'To asset',
+  minReceivedTitle: 'Minimum received',
   currentHealthFactor: 'Current health factor',
   newHealthFactor: 'New health factor',
   maximumSlippage: 'Maximum slippage',
-  fees: 'Fees',
+  fees: 'Flashloan fee',
 
   balanceNotEnough: 'Your balance in the pool is not enough',
   healthDropBellow: 'Health factor can drop bellow one after swap',

--- a/src/modules/asset-swap/screens/AssetSwapMain/index.tsx
+++ b/src/modules/asset-swap/screens/AssetSwapMain/index.tsx
@@ -113,7 +113,8 @@ export default function AssetSwapMain() {
   );
   const toAssetUserData = user.reservesData.find((res) => res.reserve.underlyingAsset === toAsset);
 
-  const maxAmountToSwap = fromAssetUserData?.underlyingBalance || '0';
+  const availableFromAmount = fromAssetUserData?.underlyingBalance || '0';
+  const availableToAmount = toAssetUserData?.underlyingBalance || '0';
 
   const usdValueSlippage = +fromAmountInUSD
     ? valueToBigNumber(fromAmountInUSD)
@@ -171,10 +172,12 @@ export default function AssetSwapMain() {
         fromAsset,
         toAsset,
         fromAmount,
-        toAmount: toAmountWithSlippage.toString(10),
+        toAmount: toAmount,
+        toAmountInUSD: toAmountInUSD,
         maxSlippage,
         fromAmountInUSD,
-        toAmountInUSD: toAmountInUSDWithSlippage.toString(10),
+        toAmountAfterSlippage: toAmountWithSlippage.toString(10),
+        toAmountInUSDAfterSlippage: toAmountInUSDWithSlippage.toString(10),
         swapAll: isMaxSelected,
         totalFees,
       });
@@ -229,7 +232,7 @@ export default function AssetSwapMain() {
               amount={fromAmount}
               onChangeAmount={setAmountFrom}
               setMaxSelected={setIsMaxSelected}
-              maxAmount={maxAmountToSwap}
+              maxAmount={availableFromAmount}
               amountInUsd={fromAmountInUSD}
               amountTitle={intl.formatMessage(messages.available)}
               disabled={!fromAsset}
@@ -245,10 +248,10 @@ export default function AssetSwapMain() {
               setAsset={setAssetTo}
               options={availableDestinationsSymbols}
               selectTitle={intl.formatMessage(messages.toTitle)}
-              amount={toAmountWithSlippage.toString(10)}
+              amount={toAmount}
               onChangeAmount={() => {}}
-              amountInUsd={toAmountInUSDWithSlippage.toString(10)}
-              percentDifference={(+usdValueSlippage - +maxSlippage).toString()}
+              amountInUsd={toAmountInUSD}
+              percentDifference={(+usdValueSlippage).toString()}
               selectReverseTitle={!md}
               disabled={true}
               loading={loading}


### PR DESCRIPTION
currently the swap ui just shows the "worst possible outcome after slippage"

This pr, changes it so in addition to the "worst possible outcome" it also show the "predicted outcome".
Some design changes for the form are still missing.