### PR TITLE
fix: allow running the app with governance disabled

### DIFF
--- a/src/libs/apollo-config/client-config.ts
+++ b/src/libs/apollo-config/client-config.ts
@@ -194,27 +194,34 @@ export function getApolloClient({
   protocolDataUrl,
 }: NetworkConfig): { client: ApolloClient<NormalizedCacheObject>; wsClients: any[] } {
   const poolTheGraphLink = new HttpLink({ uri: protocolDataUrl });
-  const governanceDataLink = split(
-    ({ query }) => {
-      const definition = getMainDefinition(query);
-      return definition.kind === 'OperationDefinition' && definition.operation === 'subscription';
-    },
-    createWsLink(governanceConfig!.wsGovernanceDataUrl),
-    new HttpLink({ uri: governanceConfig!.queryGovernanceDataUrl })
-  );
+  const governanceDataLink = governanceConfig
+    ? split(
+        ({ query }) => {
+          const definition = getMainDefinition(query);
+          return (
+            definition.kind === 'OperationDefinition' && definition.operation === 'subscription'
+          );
+        },
+        createWsLink(governanceConfig.wsGovernanceDataUrl),
+        new HttpLink({ uri: governanceConfig.queryGovernanceDataUrl })
+      )
+    : undefined;
 
-  const thegraphDataLink = split(
-    ({ query }) => {
-      const definition = getMainDefinition(query);
-      return (
-        definition.kind === 'OperationDefinition' &&
-        definition.operation === 'query' &&
-        definition.name?.value === 'UserHistory'
-      );
-    },
-    poolTheGraphLink,
-    governanceDataLink
-  );
+  const thegraphDataLink =
+    governanceDataLink === undefined
+      ? poolTheGraphLink
+      : split(
+          ({ query }) => {
+            const definition = getMainDefinition(query);
+            return (
+              definition.kind === 'OperationDefinition' &&
+              definition.operation === 'query' &&
+              definition.name?.value === 'UserHistory'
+            );
+          },
+          poolTheGraphLink,
+          governanceDataLink
+        );
 
   const cachedServerDataLink = getCachedServerLink(cachingServerUrl, cachingWSServerUrl);
   const generalLink =


### PR DESCRIPTION
accidentally reverted these changes when backporting https://github.com/aave/aave-ui/pull/26/files#diff-0e89fe8116035d6eb80e3096b3eb44a0534bb910f0a915594a5e43209c7b14daR196