### PR TITLE
feat: supply permit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22435,7 +22435,8 @@
         },
         "keccak": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.1.tgz",
+          "integrity": "sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==",
           "requires": {
             "node-addon-api": "^2.0.0",
             "node-gyp-build": "^4.2.0"
@@ -22923,7 +22924,8 @@
         },
         "node-addon-api": {
           "version": "2.0.2",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
+          "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
         },
         "node-fetch": {
           "version": "2.1.2",
@@ -22932,7 +22934,8 @@
         },
         "node-gyp-build": {
           "version": "4.2.3",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
+          "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg=="
         },
         "normalize-url": {
           "version": "4.5.0",
@@ -25105,13 +25108,13 @@
               "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
               "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
               "requires": {
-                "ethereumjs-abi": "ethereumjs-abi@git+https://github.com/ethereumjs/ethereumjs-abi.git",
+                "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
                 "ethereumjs-util": "^5.1.1"
               }
             },
             "ethereumjs-abi": {
-              "version": "git+https://git@github.com/ethereumjs/ethereumjs-abi.git#ee3994657fa7a427238e6ba92a84d0b529bbcde0",
-              "from": "ethereumjs-abi@git+https://github.com/ethereumjs/ethereumjs-abi.git",
+              "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#ee3994657fa7a427238e6ba92a84d0b529bbcde0",
+              "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
               "requires": {
                 "bn.js": "^4.11.8",
                 "ethereumjs-util": "^6.0.0"

--- a/src/components/TxConfirmationView/index.tsx
+++ b/src/components/TxConfirmationView/index.tsx
@@ -32,6 +32,7 @@ import NetworkMismatch from './NetworkMismatch';
 import messages from './messages';
 import staticStyles from './style';
 import { ChainId } from '@aave/contract-helpers';
+import { useStaticPoolDataContext } from '../../libs/pool-data-provider';
 
 export interface TxConfirmationViewProps {
   caption?: string;
@@ -63,6 +64,12 @@ export interface TxConfirmationViewProps {
 
   allowedChainIds?: ChainId[];
   aTokenData?: ATokenInfo;
+
+  getPermitSignatureRequest?: () => Promise<string>;
+  getPermitEnabledTransactionData?: (
+    signature: string
+  ) => Promise<EthereumTransactionTypeExtended[]>;
+  permitEnabled?: Boolean;
 }
 
 export default function TxConfirmationView({
@@ -78,6 +85,8 @@ export default function TxConfirmationView({
   children,
 
   getTransactionsData,
+  getPermitSignatureRequest,
+  getPermitEnabledTransactionData,
   onMainTxExecuted,
   onMainTxConfirmed,
 
@@ -94,6 +103,7 @@ export default function TxConfirmationView({
   updateTransactionsData,
   allowedChainIds: _allowedChainIds,
   aTokenData,
+  permitEnabled,
 }: TxConfirmationViewProps) {
   const intl = useIntl();
   const { currentTheme } = useThemeContext();
@@ -102,12 +112,16 @@ export default function TxConfirmationView({
   const [loadingTxData, setLoadingTxData] = useState(true);
   const [backendNotAvailable, setBackendNotAvailable] = useState(false);
   const { chainId: currentMarketChainId, networkConfig } = useProtocolDataContext();
+  const { userId } = useStaticPoolDataContext();
 
   // todo: do types more sophisticated
   const [uncheckedApproveTxData, setApproveTxData] = useState({} as EthTransactionData);
   const [uncheckedActionTxData, setActionTxData] = useState({} as EthTransactionData);
   const [selectedStep, setSelectedStep] = useState(1);
   const [unlockedSteps, setUnlockedSteps] = useState(1);
+  const [unsignedPermitData, setUnsignedPermitData] = useState<string | undefined>(undefined);
+  const [permitLoading, setPermitLoading] = useState<boolean>(false);
+  const [permitError, setPermitError] = useState<string | undefined>(undefined);
 
   /**
    * For some actions like e.g. stake/gov/migration we only allow certain networks (fork, kovan, mainnet).
@@ -154,6 +168,44 @@ export default function TxConfirmationView({
       })
     : undefined;
 
+  // Create permit signature payload and trigger wallet sign
+  // If successful, use signature to generate supplyWithPermit transaction
+  const handleSubmitPermitSignature = async () => {
+    if (provider && userId && unsignedPermitData && getPermitEnabledTransactionData) {
+      try {
+        setPermitLoading(true);
+        const signer = provider.getSigner(userId);
+        const unsignedPermitDataObject = JSON.parse(unsignedPermitData);
+        let permitTypes = unsignedPermitDataObject.types;
+        // leaving this field in types throws an error
+        // Ethers computes this automatically so this type can be removed: https://github.com/ethers-io/ethers.js/issues/687#issuecomment-714069471
+        delete permitTypes['EIP712Domain'];
+        const permitSignatureResponse = await signer._signTypedData(
+          unsignedPermitDataObject.domain,
+          permitTypes,
+          unsignedPermitDataObject.message
+        );
+        console.log('SIGNATURE RESPONSE');
+        console.log(permitSignatureResponse);
+        const supplyWithPermitTx = await getPermitEnabledTransactionData(permitSignatureResponse);
+        setActionTxData({
+          txType: supplyWithPermitTx[0].txType,
+          unsignedData: supplyWithPermitTx[0].tx,
+          gas: supplyWithPermitTx[0].gas,
+          name: mainTxName,
+        });
+        setPermitLoading(false);
+        setPermitError(undefined);
+        setSelectedStep(2);
+      } catch (e) {
+        setPermitError('Error with permit signature: ' + e);
+        setPermitLoading(false);
+      }
+    } else {
+      setPermitError('Error initializing permit signature');
+    }
+  };
+
   const handleGetTxData = async () => {
     try {
       const txs = await getTransactionsData();
@@ -184,6 +236,10 @@ export default function TxConfirmationView({
           gas: actionTx.gas,
           name: mainTxName,
         });
+      }
+      if (permitEnabled && getPermitSignatureRequest) {
+        const permitTxResponse = await getPermitSignatureRequest();
+        setUnsignedPermitData(permitTxResponse);
       }
       setLoadingTxData(false);
     } catch (e) {
@@ -294,6 +350,20 @@ export default function TxConfirmationView({
                       buttonTitle={intl.formatMessage(messages.approve)}
                     />
                   )}
+                {permitEnabled && selectedStep === 1 && (
+                  <ActionExecutionBox
+                    title={`${selectedStep}/${numberOfSteps + 1} ${
+                      backendNotAvailable
+                        ? intl.formatMessage(messages.errorTitle)
+                        : intl.formatMessage(messages.permit)
+                    }`}
+                    description={approveDescription}
+                    onSubmitTransaction={async () => handleSubmitPermitSignature()}
+                    loading={permitLoading}
+                    failed={permitError}
+                    buttonTitle={intl.formatMessage(messages.permit)}
+                  />
+                )}
 
                 {actionTxData && selectedStep === numberOfSteps && (
                   <ActionExecutionBox

--- a/src/components/TxConfirmationView/messages.ts
+++ b/src/components/TxConfirmationView/messages.ts
@@ -7,6 +7,7 @@ export default defineMessages({
   successfullyExecuted: 'Your action has been successfully executed',
   nextSteps: 'Next steps',
   approve: 'Approve',
+  permit: 'Permit',
   goBack: 'Go back',
 
   checkboxText: 'Don’t ask me to approve again',

--- a/src/libs/pool-data-provider/providers/dynamic-pool-data-provider.tsx
+++ b/src/libs/pool-data-provider/providers/dynamic-pool-data-provider.tsx
@@ -27,6 +27,17 @@ export interface ComputedReserveData extends FormatReserveResponse {
   priceInMarketReferenceCurrency: string;
   avg30DaysLiquidityRate?: string;
   avg30DaysVariableBorrowRate?: string;
+  // new fields, will not be optional once use-pool-data uses a single UiPoolDataProvider
+  isPaused?: boolean;
+  debtCeiling?: string;
+  eModeCategoryId?: number;
+  borrowCap?: string;
+  supplyCap?: string;
+  eModeLtv?: number;
+  eModeLiquidationThreshold?: number;
+  eModeLiquidationBonus?: number;
+  eModePriceSource?: string;
+  eModeLabel?: string;
 }
 
 export interface UserSummary extends FormatUserSummaryResponse {

--- a/src/modules/deposit/screens/DepositConfirmation/messages.ts
+++ b/src/modules/deposit/screens/DepositConfirmation/messages.ts
@@ -5,6 +5,7 @@ export default defineMessages({
   caption: 'Deposit overview',
   boxDescription: 'Please submit to deposit',
   approveDescription: 'Please approve before depositing',
+  approveOrPermitDescription: 'Please approve or permit before depositing',
   valueRowTitle: 'Amount',
   newHealthFactor: 'New health factor',
 

--- a/src/translations/default.json
+++ b/src/translations/default.json
@@ -149,6 +149,7 @@
   "components.TxConfirmationView.TxTopInfo.showError": "Show error",
   "components.TxConfirmationView.TxTopInfo.submit": "Submit",
   "components.TxConfirmationView.approve": "Approve",
+  "components.TxConfirmationView.permit": "Permit",
   "components.TxConfirmationView.checkboxText": "Don’t ask me to approve again",
   "components.TxConfirmationView.congratulations": "Congrats!",
   "components.TxConfirmationView.errorDescription": "It is not possible to complete the transaction at the moment, please try again later.",


### PR DESCRIPTION
Add support for EIP-712 permit when calling supply on V3 pool 

Modifies the TxConfirmationView to add a permit box which triggers a signature request. Once signed, calls the supplyWithPermit function on the V3 pool to supply without requiring an approve transaction.