### PR TITLE
fix: usd calculation for gas price

### DIFF
--- a/src/components/TxEstimation/index.tsx
+++ b/src/components/TxEstimation/index.tsx
@@ -97,7 +97,7 @@ export default function TxEstimation({ getTransactionsData, amount }: TxEstimati
       <div className="TxEstimation__values">
         <Value value={Number(estimatedTx)} symbol={'ETH'} /> /
         <Value
-          value={valueToBigNumber(estimatedTx).div(marketRefPriceInUsd).toNumber()}
+          value={valueToBigNumber(estimatedTx).multipliedBy(marketRefPriceInUsd).toNumber()}
           symbol={'USD'}
         />
       </div>


### PR DESCRIPTION
Calculation was expecting old usdPriceEth, needed to flip the sign for new marketRefPriceInUSD