### PR TITLE
fix: usd pricing on tx estimate and editor

### DIFF
--- a/src/components/TxEstimationEditor/EditorModal/index.tsx
+++ b/src/components/TxEstimationEditor/EditorModal/index.tsx
@@ -176,7 +176,9 @@ export default function EditorModal({
                   <Value value={Number(estimation)} symbol="ETH" />
                   <span className="TxEstimationModal__contentValues--separator">/</span>
                   <Value
-                    value={valueToBigNumber(estimation).div(marketRefPriceInUsd).toNumber()}
+                    value={valueToBigNumber(estimation)
+                      .multipliedBy(marketRefPriceInUsd)
+                      .toNumber()}
                     symbol="USD"
                   />
                 </div>
@@ -194,7 +196,9 @@ export default function EditorModal({
               <span className="TxEstimationModal__contentValues--separator">/</span>
               <Value
                 className="TxEstimationModal__total"
-                value={valueToBigNumber(totalEstimation).div(marketRefPriceInUsd).toNumber()}
+                value={valueToBigNumber(totalEstimation)
+                  .multipliedBy(marketRefPriceInUsd)
+                  .toNumber()}
                 symbol="USD"
               />
             </div>

--- a/src/components/TxEstimationEditor/Summary/index.tsx
+++ b/src/components/TxEstimationEditor/Summary/index.tsx
@@ -46,7 +46,7 @@ export default function Summary({
         <div className="TxEstimationEditor__values">
           <Value value={Number(estimationCost)} symbol="ETH" /> /
           <Value
-            value={valueToBigNumber(estimationCost).div(marketRefPriceInUsd).toNumber()}
+            value={valueToBigNumber(estimationCost).multipliedBy(marketRefPriceInUsd).toNumber()}
             symbol="USD"
           />
         </div>


### PR DESCRIPTION
On confirmation and editor screens, the estimated tx price in USD is still incorrect