### PR TITLE
fix: fix network naming

### DIFF
--- a/src/components/ConnectWalletModal/components/SelectPreferredNetwork/messages.ts
+++ b/src/components/ConnectWalletModal/components/SelectPreferredNetwork/messages.ts
@@ -3,7 +3,7 @@ import { defineMessages } from 'react-intl';
 export default defineMessages({
   title: 'Select preferred network',
 
-  mainnet: '{network} Mainnet',
+  mainnet: '{network}',
   testNetwork: '{network} Test Network',
   forkNetwork: '{network} Fork Network',
 });

--- a/src/ui-config/networks.ts
+++ b/src/ui-config/networks.ts
@@ -28,7 +28,7 @@ export const networkConfigs: Record<string, BaseNetworkConfig> = {
     isTestnet: true,
   },
   [ChainId.mainnet]: {
-    name: 'Mainnet',
+    name: 'Ethereum mainnet',
     publicJsonRPCUrl: ['https://cloudflare-eth.com', 'https://eth-mainnet.alchemyapi.io/v2/demo'],
     publicJsonRPCWSUrl: 'wss://eth-mainnet.alchemyapi.io/v2/demo',
     addresses: {

--- a/src/ui-config/networks.ts
+++ b/src/ui-config/networks.ts
@@ -28,7 +28,7 @@ export const networkConfigs: Record<string, BaseNetworkConfig> = {
     isTestnet: true,
   },
   [ChainId.mainnet]: {
-    name: 'Ethereum Mainnet',
+    name: 'Mainnet',
     publicJsonRPCUrl: ['https://cloudflare-eth.com', 'https://eth-mainnet.alchemyapi.io/v2/demo'],
     publicJsonRPCWSUrl: 'wss://eth-mainnet.alchemyapi.io/v2/demo',
     addresses: {


### PR DESCRIPTION
In a recent change the strict alignment with network names on aave-js was removed so that people can use the ui with unsupported chains more easily. This also removed the special case handling of etherum mainnet.

- closes #187