### PR TITLE
fix: manually set proposalstate to expired

### DIFF
--- a/src/libs/governance-provider/helper.tsx
+++ b/src/libs/governance-provider/helper.tsx
@@ -37,6 +37,10 @@ export const getCorrectState = (proposal: ProposalItem) => {
     return quorumValid && differentialValid ? ProposalState.Succeeded : ProposalState.Failed;
   }
 
+  if (hasEnded && proposal.state === ProposalState.Queued) {
+    return ProposalState.Expired;
+  }
+
   // When there has never been a single vote, no event has been triggered which could have transitioned the state.
   if (proposal.state === ProposalState.Pending) {
     if (hasEnded) return ProposalState.Failed;


### PR DESCRIPTION
there's no event for expiration so when data comes from thegraph(which generates state from events) it will always show as queued when there's no execution. Therefore we manually have to alter the state to expired when sth is queued, but never executed.