### PR TITLE
fix: imports `TokenIcon` component from `'@aave/aave-ui-kit` to `help…

### DIFF
--- a/src/components/IncentiveClaimItem/index.tsx
+++ b/src/components/IncentiveClaimItem/index.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { useIntl } from 'react-intl';
-import { CustomTooltip, TokenIcon, useThemeContext } from '@aave/aave-ui-kit';
+import { CustomTooltip, useThemeContext } from '@aave/aave-ui-kit';
 
 import Value from '../basic/Value';
 import Link from '../basic/Link';
+import { TokenIcon } from '../../helpers/config/assets-config';
 
 import defaultMessages from '../../defaultMessages';
 import staticStyles from './style';

--- a/src/components/liquidityMining/LiquidityMiningAPYLine/index.tsx
+++ b/src/components/liquidityMining/LiquidityMiningAPYLine/index.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { useIntl } from 'react-intl';
 import ReactTooltip from 'react-tooltip';
-import { rgba, TokenIcon, useThemeContext } from '@aave/aave-ui-kit';
+import { rgba, useThemeContext } from '@aave/aave-ui-kit';
 import classNames from 'classnames';
 
+import { TokenIcon } from '../../../helpers/config/assets-config';
 import { useProtocolDataContext } from '../../../libs/protocol-data-provider';
 import ValuePercent from '../../basic/ValuePercent';
 import TribeRewardHelpModal from '../../HelpModal/TribeRewardHelpModal';


### PR DESCRIPTION
fix: imports `TokenIcon` component from `'@aave/aave-ui-kit` to `helpers/config/assets-config`