### PR TITLE
feat: allow logging in from unsupported chain

### DIFF
--- a/src/helpers/config/markets-and-network-config.tsx
+++ b/src/helpers/config/markets-and-network-config.tsx
@@ -1,4 +1,4 @@
-import { ChainId } from '@aave/contract-helpers';
+import { ChainId, ChainIdToNetwork } from '@aave/contract-helpers';
 
 import { networkConfigs as _networkConfigs } from '../../ui-config/networks';
 import { CustomMarket, marketsData as _marketsData } from '../../ui-config/markets/index';
@@ -102,7 +102,12 @@ const linkBuilder =
 export function getNetworkConfig(chainId: ChainId): NetworkConfig {
   const config = networkConfigs[chainId];
   if (!config) {
-    throw new Error(`Network with chainId "${chainId}" was not configured`);
+    // this case can only ever occure when a wallet is connected with a unknown chainId which will not allow interaction
+    const name = ChainIdToNetwork[chainId];
+    return {
+      name: name || `unknown chainId: ${chainId}`,
+      explorerLinkBuilder: () => {},
+    } as unknown as NetworkConfig;
   }
   return { ...config, explorerLinkBuilder: linkBuilder({ baseUrl: config.explorerLink }) };
 }

--- a/src/libs/web3-data-provider/web3-providers/connectors.tsx
+++ b/src/libs/web3-data-provider/web3-providers/connectors.tsx
@@ -18,10 +18,7 @@ import {
   getFortmaticKeyByChainId,
   PORTIS_DAPP_ID,
 } from '../../../helpers/config/wallet-config';
-import {
-  getSupportedChainIds,
-  getNetworkConfig,
-} from '../../../helpers/config/markets-and-network-config';
+import { getNetworkConfig } from '../../../helpers/config/markets-and-network-config';
 import { ChainId } from '@aave/contract-helpers';
 
 export type AvailableWeb3Connectors =
@@ -65,7 +62,7 @@ export function getWeb3Connector(
 
   switch (connectorName) {
     case 'browser':
-      return new InjectedConnector({ supportedChainIds: getSupportedChainIds() });
+      return new InjectedConnector({});
     case 'ledger':
       return new LedgerConnector({
         chainId,


### PR DESCRIPTION
when using mm and you are connected to a network which is not mentioned in network config e.g. ropsten, you currently can't login and the login widget will just flash. This pr adjusts the behavior to allow arbitrary chain logins from injected providers.