### PR TITLE
feat/reserve overview back button

### DIFF
--- a/src/modules/reserve-overview/components/ReserveInformation/index.tsx
+++ b/src/modules/reserve-overview/components/ReserveInformation/index.tsx
@@ -78,7 +78,7 @@ export default function ReserveInformation({
       <div className="ReserveInformation__inner">
         <h3 className="ReserveInformation__title">{intl.formatMessage(messages.caption)}</h3>
 
-        <ContentWrapper className="ReserveInformation__content">
+        <ContentWrapper className="ReserveInformation__content" withBackButton={true}>
           {poolLink && (
             <div className="ReserveInformation__poolLink-inner">
               <p>


### PR DESCRIPTION
Since the Reserve Overview screen is now reachable from Dashboard and Markets, it makes sense to have a back button to return to the previous screen.