### PR TITLE
Enable addEthereumChain+switchEthereumChain requests for Coinbase Wallet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "@web3-react/injected-connector": "^6.0.7",
         "@web3-react/portis-connector": "^6.1.9",
         "@web3-react/torus-connector": "^6.1.9",
-        "@web3-react/walletlink-connector": "^6.2.8",
+        "@web3-react/walletlink-connector": "^6.2.11",
         "classnames": "^2.3.1",
         "d3-array": "^3.1.1",
         "dayjs": "^1.10.7",
@@ -10173,13 +10173,13 @@
       "integrity": "sha512-ofGmfDhxmNT1/P/MgVa8IKSkCStFiyvXe+U5tyZurKdrtTDFU+wJ/LxClPDtFerWpczNFPUSrKcuhfPX1sI6+A=="
     },
     "node_modules/@web3-react/walletlink-connector": {
-      "version": "6.2.8",
-      "resolved": "https://registry.npmjs.org/@web3-react/walletlink-connector/-/walletlink-connector-6.2.8.tgz",
-      "integrity": "sha512-pSGufPz5JntSUvy88XcOrn5VN3qmX+ZVQ2lXAeWWb7YS2wTlAStPghZbln8t1li7jr1NUJ0w/gMDVpAwjwq4ZA==",
+      "version": "6.2.11",
+      "resolved": "https://registry.npmjs.org/@web3-react/walletlink-connector/-/walletlink-connector-6.2.11.tgz",
+      "integrity": "sha512-S9uiugqS/Taw8FRllHMlsM1EIl8f0XTbNhBSUH3DeOkyc+nsnNuH6dJ15OUe52CPYMTkJhmBuCVUpAWyAJIXmg==",
       "dependencies": {
         "@web3-react/abstract-connector": "^6.0.7",
         "@web3-react/types": "^6.0.7",
-        "walletlink": "^2.2.6"
+        "walletlink": "^2.4.6"
       }
     },
     "node_modules/@webassemblyjs/ast": {
@@ -53353,9 +53353,9 @@
       }
     },
     "node_modules/walletlink": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/walletlink/-/walletlink-2.4.3.tgz",
-      "integrity": "sha512-IGZZPhzuDStQtX3bKvVfD2AKb1HoSVBKwuU528+9S5JdzBGb1ZPEAXHh9yzHtamgqyHOpiGSrkop/rZ7NM52SQ==",
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/walletlink/-/walletlink-2.4.6.tgz",
+      "integrity": "sha512-CtfyRa3Tc9yTRFIoE0P0rhiq57WB6/XnJ0Fyc3tmSR4yntFP29sqp+SCDOI0R9Ot20gAKaYb2w/nnmLRrhfiJQ==",
       "dependencies": {
         "@metamask/safe-event-emitter": "2.0.0",
         "bind-decorator": "^1.0.11",
@@ -53422,9 +53422,9 @@
       }
     },
     "node_modules/walletlink/node_modules/preact": {
-      "version": "10.6.4",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.6.4.tgz",
-      "integrity": "sha512-WyosM7pxGcndU8hY0OQlLd54tOU+qmG45QXj2dAYrL11HoyU/EzOSTlpJsirbBr1QW7lICxSsVJJmcmUglovHQ==",
+      "version": "10.6.5",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.6.5.tgz",
+      "integrity": "sha512-i+LXM6JiVjQXSt2jG2vZZFapGpCuk1fl8o6ii3G84MA3xgj686FKjs4JFDkmUVhtxyq21+4ay74zqPykz9hU6w==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -64200,13 +64200,13 @@
       "integrity": "sha512-ofGmfDhxmNT1/P/MgVa8IKSkCStFiyvXe+U5tyZurKdrtTDFU+wJ/LxClPDtFerWpczNFPUSrKcuhfPX1sI6+A=="
     },
     "@web3-react/walletlink-connector": {
-      "version": "6.2.8",
-      "resolved": "https://registry.npmjs.org/@web3-react/walletlink-connector/-/walletlink-connector-6.2.8.tgz",
-      "integrity": "sha512-pSGufPz5JntSUvy88XcOrn5VN3qmX+ZVQ2lXAeWWb7YS2wTlAStPghZbln8t1li7jr1NUJ0w/gMDVpAwjwq4ZA==",
+      "version": "6.2.11",
+      "resolved": "https://registry.npmjs.org/@web3-react/walletlink-connector/-/walletlink-connector-6.2.11.tgz",
+      "integrity": "sha512-S9uiugqS/Taw8FRllHMlsM1EIl8f0XTbNhBSUH3DeOkyc+nsnNuH6dJ15OUe52CPYMTkJhmBuCVUpAWyAJIXmg==",
       "requires": {
         "@web3-react/abstract-connector": "^6.0.7",
         "@web3-react/types": "^6.0.7",
-        "walletlink": "^2.2.6"
+        "walletlink": "^2.4.6"
       }
     },
     "@webassemblyjs/ast": {
@@ -98618,9 +98618,9 @@
       }
     },
     "walletlink": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/walletlink/-/walletlink-2.4.3.tgz",
-      "integrity": "sha512-IGZZPhzuDStQtX3bKvVfD2AKb1HoSVBKwuU528+9S5JdzBGb1ZPEAXHh9yzHtamgqyHOpiGSrkop/rZ7NM52SQ==",
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/walletlink/-/walletlink-2.4.6.tgz",
+      "integrity": "sha512-CtfyRa3Tc9yTRFIoE0P0rhiq57WB6/XnJ0Fyc3tmSR4yntFP29sqp+SCDOI0R9Ot20gAKaYb2w/nnmLRrhfiJQ==",
       "requires": {
         "@metamask/safe-event-emitter": "2.0.0",
         "bind-decorator": "^1.0.11",
@@ -98678,9 +98678,9 @@
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
         },
         "preact": {
-          "version": "10.6.4",
-          "resolved": "https://registry.npmjs.org/preact/-/preact-10.6.4.tgz",
-          "integrity": "sha512-WyosM7pxGcndU8hY0OQlLd54tOU+qmG45QXj2dAYrL11HoyU/EzOSTlpJsirbBr1QW7lICxSsVJJmcmUglovHQ=="
+          "version": "10.6.5",
+          "resolved": "https://registry.npmjs.org/preact/-/preact-10.6.5.tgz",
+          "integrity": "sha512-i+LXM6JiVjQXSt2jG2vZZFapGpCuk1fl8o6ii3G84MA3xgj686FKjs4JFDkmUVhtxyq21+4ay74zqPykz9hU6w=="
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -23013,6 +23013,8 @@
     },
     "node_modules/ganache-core/node_modules/@ethersproject/abi": {
       "version": "5.0.0-beta.153",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.0-beta.153.tgz",
+      "integrity": "sha512-aXweZ1Z7vMNzJdLpR1CZUAIgnwjrZeUSvN9syCwlBaEBUFJmFY+HHnfuTI5vIhVs/mRkfJVrbEyl51JZQqyjAg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -23374,6 +23376,8 @@
     },
     "node_modules/ganache-core/node_modules/@sindresorhus/is": {
       "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
+      "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -23382,6 +23386,8 @@
     },
     "node_modules/ganache-core/node_modules/@szmarczak/http-timer": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
+      "integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -23393,6 +23399,8 @@
     },
     "node_modules/ganache-core/node_modules/@types/bn.js": {
       "version": "4.11.6",
+      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
+      "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -23404,6 +23412,8 @@
     },
     "node_modules/ganache-core/node_modules/@types/pbkdf2": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/pbkdf2/-/pbkdf2-3.1.0.tgz",
+      "integrity": "sha512-Cf63Rv7jCQ0LaL8tNXmEyqTHuIJxRdlS5vMh1mj5voN4+QFhVZnlZruezqpWYDiJ8UTzhP0VmeLXCmBk66YrMQ==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -23418,10 +23428,14 @@
     },
     "node_modules/ganache-core/node_modules/@yarnpkg/lockfile": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
       "license": "BSD-2-Clause"
     },
     "node_modules/ganache-core/node_modules/abstract-leveldown": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-3.0.0.tgz",
+      "integrity": "sha512-KUWx9UWGQD12zsmLNj64/pndaz4iJh/Pj7nopgkfDG6RlCcbMZvT6+9l7dchK4idog2Is8VdC/PvNbFuFmalIQ==",
       "license": "MIT",
       "dependencies": {
         "xtend": "~4.0.0"
@@ -23432,6 +23446,8 @@
     },
     "node_modules/ganache-core/node_modules/accepts": {
       "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
+      "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -23444,11 +23460,15 @@
     },
     "node_modules/ganache-core/node_modules/aes-js": {
       "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.1.2.tgz",
+      "integrity": "sha512-e5pEa2kBnBOgR4Y/p20pskXI74UEz7de8ZGVo58asOtvSVG5YAbJeELPZxOmt+Bnz3rX753YKhfIn4X4l1PPRQ==",
       "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/ajv": {
       "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -23463,6 +23483,8 @@
     },
     "node_modules/ganache-core/node_modules/ansi-styles": {
       "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "license": "MIT",
       "dependencies": {
         "color-convert": "^1.9.0"
@@ -23473,6 +23495,8 @@
     },
     "node_modules/ganache-core/node_modules/arr-diff": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -23480,6 +23504,8 @@
     },
     "node_modules/ganache-core/node_modules/arr-flatten": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -23487,6 +23513,8 @@
     },
     "node_modules/ganache-core/node_modules/arr-union": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -23494,11 +23522,15 @@
     },
     "node_modules/ganache-core/node_modules/array-flatten": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
       "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/array-unique": {
       "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -23506,6 +23538,8 @@
     },
     "node_modules/ganache-core/node_modules/asn1": {
       "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": "~2.1.0"
@@ -23513,6 +23547,8 @@
     },
     "node_modules/ganache-core/node_modules/asn1.js": {
       "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -23524,6 +23560,8 @@
     },
     "node_modules/ganache-core/node_modules/assert-plus": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
       "license": "MIT",
       "engines": {
         "node": ">=0.8"
@@ -23531,6 +23569,8 @@
     },
     "node_modules/ganache-core/node_modules/assign-symbols": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -23538,6 +23578,8 @@
     },
     "node_modules/ganache-core/node_modules/async": {
       "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
+      "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.11"
@@ -23545,6 +23587,8 @@
     },
     "node_modules/ganache-core/node_modules/async-eventemitter": {
       "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/async-eventemitter/-/async-eventemitter-0.2.4.tgz",
+      "integrity": "sha512-pd20BwL7Yt1zwDFy+8MX8F1+WCT8aQeKj0kQnTrH9WaeRETlRamVhD0JtRPmrV4GfOJ2F9CvdQkZeZhnh2TuHw==",
       "license": "MIT",
       "dependencies": {
         "async": "^2.4.0"
@@ -23552,14 +23596,20 @@
     },
     "node_modules/ganache-core/node_modules/async-limiter": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/asynckit": {
       "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/atob": {
       "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "license": "(MIT OR Apache-2.0)",
       "bin": {
         "atob": "bin/atob.js"
@@ -23570,6 +23620,8 @@
     },
     "node_modules/ganache-core/node_modules/aws-sign2": {
       "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
       "license": "Apache-2.0",
       "engines": {
         "node": "*"
@@ -23577,10 +23629,14 @@
     },
     "node_modules/ganache-core/node_modules/aws4": {
       "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
+      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/babel-code-frame": {
       "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "license": "MIT",
       "dependencies": {
         "chalk": "^1.1.3",
@@ -23590,6 +23646,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-code-frame/node_modules/ansi-regex": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -23597,6 +23655,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-code-frame/node_modules/ansi-styles": {
       "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -23604,6 +23664,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-code-frame/node_modules/chalk": {
       "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^2.2.1",
@@ -23618,10 +23680,14 @@
     },
     "node_modules/ganache-core/node_modules/babel-code-frame/node_modules/js-tokens": {
       "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/babel-code-frame/node_modules/strip-ansi": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^2.0.0"
@@ -23632,6 +23698,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-code-frame/node_modules/supports-color": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
@@ -23639,6 +23707,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-core": {
       "version": "6.26.3",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
+      "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
       "license": "MIT",
       "dependencies": {
         "babel-code-frame": "^6.26.0",
@@ -23664,6 +23734,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-core/node_modules/debug": {
       "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -23671,6 +23743,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-core/node_modules/json5": {
       "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
       "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
@@ -23678,10 +23752,14 @@
     },
     "node_modules/ganache-core/node_modules/babel-core/node_modules/ms": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/babel-core/node_modules/slash": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -23689,6 +23767,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-generator": {
       "version": "6.26.1",
+      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
+      "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
       "license": "MIT",
       "dependencies": {
         "babel-messages": "^6.23.0",
@@ -23703,6 +23783,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-generator/node_modules/jsesc": {
       "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+      "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
@@ -23710,6 +23792,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-helper-builder-binary-assignment-operator-visitor": {
       "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
+      "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
       "license": "MIT",
       "dependencies": {
         "babel-helper-explode-assignable-expression": "^6.24.1",
@@ -23719,6 +23803,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-helper-call-delegate": {
       "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
+      "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
       "license": "MIT",
       "dependencies": {
         "babel-helper-hoist-variables": "^6.24.1",
@@ -23729,6 +23815,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-helper-define-map": {
       "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
+      "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
       "license": "MIT",
       "dependencies": {
         "babel-helper-function-name": "^6.24.1",
@@ -23739,6 +23827,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-helper-explode-assignable-expression": {
       "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
+      "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
       "license": "MIT",
       "dependencies": {
         "babel-runtime": "^6.22.0",
@@ -23748,6 +23838,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-helper-function-name": {
       "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+      "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
       "license": "MIT",
       "dependencies": {
         "babel-helper-get-function-arity": "^6.24.1",
@@ -23759,6 +23851,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-helper-get-function-arity": {
       "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+      "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
       "license": "MIT",
       "dependencies": {
         "babel-runtime": "^6.22.0",
@@ -23767,6 +23861,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-helper-hoist-variables": {
       "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
+      "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
       "license": "MIT",
       "dependencies": {
         "babel-runtime": "^6.22.0",
@@ -23775,6 +23871,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-helper-optimise-call-expression": {
       "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
+      "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
       "license": "MIT",
       "dependencies": {
         "babel-runtime": "^6.22.0",
@@ -23783,6 +23881,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-helper-regex": {
       "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
+      "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
       "license": "MIT",
       "dependencies": {
         "babel-runtime": "^6.26.0",
@@ -23792,6 +23892,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-helper-remap-async-to-generator": {
       "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
+      "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
       "license": "MIT",
       "dependencies": {
         "babel-helper-function-name": "^6.24.1",
@@ -23803,6 +23905,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-helper-replace-supers": {
       "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
+      "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
       "license": "MIT",
       "dependencies": {
         "babel-helper-optimise-call-expression": "^6.24.1",
@@ -23815,6 +23919,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-helpers": {
       "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+      "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
       "license": "MIT",
       "dependencies": {
         "babel-runtime": "^6.22.0",
@@ -23823,6 +23929,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-messages": {
       "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "license": "MIT",
       "dependencies": {
         "babel-runtime": "^6.22.0"
@@ -23830,6 +23938,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-plugin-check-es2015-constants": {
       "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
+      "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
       "license": "MIT",
       "dependencies": {
         "babel-runtime": "^6.22.0"
@@ -23837,18 +23947,26 @@
     },
     "node_modules/ganache-core/node_modules/babel-plugin-syntax-async-functions": {
       "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
+      "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/babel-plugin-syntax-exponentiation-operator": {
       "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
+      "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/babel-plugin-syntax-trailing-function-commas": {
       "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
+      "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/babel-plugin-transform-async-to-generator": {
       "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
+      "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
       "license": "MIT",
       "dependencies": {
         "babel-helper-remap-async-to-generator": "^6.24.1",
@@ -23858,6 +23976,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-plugin-transform-es2015-arrow-functions": {
       "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
+      "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
       "license": "MIT",
       "dependencies": {
         "babel-runtime": "^6.22.0"
@@ -23865,6 +23985,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-plugin-transform-es2015-block-scoped-functions": {
       "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
+      "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
       "license": "MIT",
       "dependencies": {
         "babel-runtime": "^6.22.0"
@@ -23872,6 +23994,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-plugin-transform-es2015-block-scoping": {
       "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
+      "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
       "license": "MIT",
       "dependencies": {
         "babel-runtime": "^6.26.0",
@@ -23883,6 +24007,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-plugin-transform-es2015-classes": {
       "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
+      "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
       "license": "MIT",
       "dependencies": {
         "babel-helper-define-map": "^6.24.1",
@@ -23898,6 +24024,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-plugin-transform-es2015-computed-properties": {
       "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
+      "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
       "license": "MIT",
       "dependencies": {
         "babel-runtime": "^6.22.0",
@@ -23906,6 +24034,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-plugin-transform-es2015-destructuring": {
       "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+      "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
       "license": "MIT",
       "dependencies": {
         "babel-runtime": "^6.22.0"
@@ -23913,6 +24043,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-plugin-transform-es2015-duplicate-keys": {
       "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
+      "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
       "license": "MIT",
       "dependencies": {
         "babel-runtime": "^6.22.0",
@@ -23921,6 +24053,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-plugin-transform-es2015-for-of": {
       "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
+      "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
       "license": "MIT",
       "dependencies": {
         "babel-runtime": "^6.22.0"
@@ -23928,6 +24062,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-plugin-transform-es2015-function-name": {
       "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
+      "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
       "license": "MIT",
       "dependencies": {
         "babel-helper-function-name": "^6.24.1",
@@ -23937,6 +24073,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-plugin-transform-es2015-literals": {
       "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
+      "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
       "license": "MIT",
       "dependencies": {
         "babel-runtime": "^6.22.0"
@@ -23944,6 +24082,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-plugin-transform-es2015-modules-amd": {
       "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
+      "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
       "license": "MIT",
       "dependencies": {
         "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
@@ -23953,6 +24093,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-plugin-transform-es2015-modules-commonjs": {
       "version": "6.26.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
+      "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
       "license": "MIT",
       "dependencies": {
         "babel-plugin-transform-strict-mode": "^6.24.1",
@@ -23963,6 +24105,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-plugin-transform-es2015-modules-systemjs": {
       "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
+      "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
       "license": "MIT",
       "dependencies": {
         "babel-helper-hoist-variables": "^6.24.1",
@@ -23972,6 +24116,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-plugin-transform-es2015-modules-umd": {
       "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
+      "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
       "license": "MIT",
       "dependencies": {
         "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
@@ -23981,6 +24127,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-plugin-transform-es2015-object-super": {
       "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
+      "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
       "license": "MIT",
       "dependencies": {
         "babel-helper-replace-supers": "^6.24.1",
@@ -23989,6 +24137,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-plugin-transform-es2015-parameters": {
       "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
+      "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
       "license": "MIT",
       "dependencies": {
         "babel-helper-call-delegate": "^6.24.1",
@@ -24001,6 +24151,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-plugin-transform-es2015-shorthand-properties": {
       "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
+      "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
       "license": "MIT",
       "dependencies": {
         "babel-runtime": "^6.22.0",
@@ -24009,6 +24161,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-plugin-transform-es2015-spread": {
       "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
+      "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
       "license": "MIT",
       "dependencies": {
         "babel-runtime": "^6.22.0"
@@ -24016,6 +24170,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-plugin-transform-es2015-sticky-regex": {
       "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
+      "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
       "license": "MIT",
       "dependencies": {
         "babel-helper-regex": "^6.24.1",
@@ -24025,6 +24181,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-plugin-transform-es2015-template-literals": {
       "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
+      "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
       "license": "MIT",
       "dependencies": {
         "babel-runtime": "^6.22.0"
@@ -24032,6 +24190,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-plugin-transform-es2015-typeof-symbol": {
       "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
+      "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
       "license": "MIT",
       "dependencies": {
         "babel-runtime": "^6.22.0"
@@ -24039,6 +24199,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-plugin-transform-es2015-unicode-regex": {
       "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
+      "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
       "license": "MIT",
       "dependencies": {
         "babel-helper-regex": "^6.24.1",
@@ -24048,6 +24210,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-plugin-transform-exponentiation-operator": {
       "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
+      "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
       "license": "MIT",
       "dependencies": {
         "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
@@ -24057,6 +24221,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-plugin-transform-regenerator": {
       "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
+      "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
       "license": "MIT",
       "dependencies": {
         "regenerator-transform": "^0.10.0"
@@ -24064,6 +24230,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-plugin-transform-strict-mode": {
       "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
+      "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
       "license": "MIT",
       "dependencies": {
         "babel-runtime": "^6.22.0",
@@ -24072,6 +24240,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-preset-env": {
       "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.7.0.tgz",
+      "integrity": "sha512-9OR2afuKDneX2/q2EurSftUYM0xGu4O2D9adAhVfADDhrYDaxXV0rBbevVYoY9n6nyX1PmQW/0jtpJvUNr9CHg==",
       "license": "MIT",
       "dependencies": {
         "babel-plugin-check-es2015-constants": "^6.22.0",
@@ -24108,6 +24278,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-preset-env/node_modules/semver": {
       "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver"
@@ -24115,6 +24287,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-register": {
       "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
+      "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
       "license": "MIT",
       "dependencies": {
         "babel-core": "^6.26.0",
@@ -24128,6 +24302,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-register/node_modules/source-map-support": {
       "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
       "license": "MIT",
       "dependencies": {
         "source-map": "^0.5.6"
@@ -24135,6 +24311,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-runtime": {
       "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "license": "MIT",
       "dependencies": {
         "core-js": "^2.4.0",
@@ -24143,6 +24321,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-template": {
       "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+      "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
       "license": "MIT",
       "dependencies": {
         "babel-runtime": "^6.26.0",
@@ -24154,6 +24334,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-traverse": {
       "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+      "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
       "license": "MIT",
       "dependencies": {
         "babel-code-frame": "^6.26.0",
@@ -24169,6 +24351,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-traverse/node_modules/debug": {
       "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -24176,6 +24360,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-traverse/node_modules/globals": {
       "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -24183,10 +24369,14 @@
     },
     "node_modules/ganache-core/node_modules/babel-traverse/node_modules/ms": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/babel-types": {
       "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "license": "MIT",
       "dependencies": {
         "babel-runtime": "^6.26.0",
@@ -24197,6 +24387,8 @@
     },
     "node_modules/ganache-core/node_modules/babel-types/node_modules/to-fast-properties": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -24204,6 +24396,8 @@
     },
     "node_modules/ganache-core/node_modules/babelify": {
       "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/babelify/-/babelify-7.3.0.tgz",
+      "integrity": "sha1-qlau3nBn/XvVSWZu4W3ChQh+iOU=",
       "license": "MIT",
       "dependencies": {
         "babel-core": "^6.0.14",
@@ -24212,6 +24406,8 @@
     },
     "node_modules/ganache-core/node_modules/babylon": {
       "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
       "license": "MIT",
       "bin": {
         "babylon": "bin/babylon.js"
@@ -24219,6 +24415,8 @@
     },
     "node_modules/ganache-core/node_modules/backoff": {
       "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.5.0.tgz",
+      "integrity": "sha1-9hbtqdPktmuMp/ynn2lXIsX44m8=",
       "license": "MIT",
       "dependencies": {
         "precond": "0.2"
@@ -24233,6 +24431,8 @@
     },
     "node_modules/ganache-core/node_modules/base": {
       "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "license": "MIT",
       "dependencies": {
         "cache-base": "^1.0.1",
@@ -24249,6 +24449,8 @@
     },
     "node_modules/ganache-core/node_modules/base-x": {
       "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
+      "integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "^5.0.1"
@@ -24256,6 +24458,8 @@
     },
     "node_modules/ganache-core/node_modules/base/node_modules/define-property": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+      "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
       "license": "MIT",
       "dependencies": {
         "is-descriptor": "^1.0.0"
@@ -24266,6 +24470,8 @@
     },
     "node_modules/ganache-core/node_modules/base64-js": {
       "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
       "funding": [
         {
           "type": "github",
@@ -24284,6 +24490,8 @@
     },
     "node_modules/ganache-core/node_modules/bcrypt-pbkdf": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "license": "BSD-3-Clause",
       "dependencies": {
         "tweetnacl": "^0.14.3"
@@ -24291,10 +24499,14 @@
     },
     "node_modules/ganache-core/node_modules/bcrypt-pbkdf/node_modules/tweetnacl": {
       "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "license": "Unlicense"
     },
     "node_modules/ganache-core/node_modules/bignumber.js": {
       "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
+      "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -24303,6 +24515,8 @@
     },
     "node_modules/ganache-core/node_modules/bip39": {
       "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/bip39/-/bip39-2.5.0.tgz",
+      "integrity": "sha512-xwIx/8JKoT2+IPJpFEfXoWdYwP7UVAoUxxLNfGCfVowaJE7yg1Y5B1BVPqlUNsBq5/nGwmFkwRJ8xDW4sX8OdA==",
       "license": "ISC",
       "dependencies": {
         "create-hash": "^1.1.0",
@@ -24318,6 +24532,8 @@
     },
     "node_modules/ganache-core/node_modules/bluebird": {
       "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
       "license": "MIT",
       "optional": true
     },
@@ -24327,6 +24543,8 @@
     },
     "node_modules/ganache-core/node_modules/body-parser": {
       "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
+      "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -24347,6 +24565,8 @@
     },
     "node_modules/ganache-core/node_modules/body-parser/node_modules/debug": {
       "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -24355,11 +24575,15 @@
     },
     "node_modules/ganache-core/node_modules/body-parser/node_modules/ms": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/body-parser/node_modules/qs": {
       "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+      "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
       "license": "BSD-3-Clause",
       "optional": true,
       "engines": {
@@ -24368,6 +24592,8 @@
     },
     "node_modules/ganache-core/node_modules/brace-expansion": {
       "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -24376,10 +24602,14 @@
     },
     "node_modules/ganache-core/node_modules/brorand": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/browserify-aes": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "license": "MIT",
       "dependencies": {
         "buffer-xor": "^1.0.3",
@@ -24392,6 +24622,8 @@
     },
     "node_modules/ganache-core/node_modules/browserify-cipher": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+      "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -24402,6 +24634,8 @@
     },
     "node_modules/ganache-core/node_modules/browserify-des": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
+      "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -24413,6 +24647,8 @@
     },
     "node_modules/ganache-core/node_modules/browserify-rsa": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.0.tgz",
+      "integrity": "sha512-AdEER0Hkspgno2aR97SAf6vi0y0k8NuOpGnVH3O99rcA5Q6sh8QxcngtHuJ6uXwnfAXNM4Gn1Gb7/MV1+Ymbog==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -24427,6 +24663,8 @@
     },
     "node_modules/ganache-core/node_modules/browserify-sign": {
       "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.1.tgz",
+      "integrity": "sha512-/vrA5fguVAKKAVTNJjgSm1tRQDHUU6DbwO9IROu/0WAzC8PKhucDSh18J0RMvVeHAn5puMd+QHC2erPRNf8lmg==",
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -24448,6 +24686,8 @@
     },
     "node_modules/ganache-core/node_modules/browserify-sign/node_modules/readable-stream": {
       "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -24461,6 +24701,8 @@
     },
     "node_modules/ganache-core/node_modules/browserslist": {
       "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.8.tgz",
+      "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
       "license": "MIT",
       "dependencies": {
         "caniuse-lite": "^1.0.30000844",
@@ -24472,6 +24714,8 @@
     },
     "node_modules/ganache-core/node_modules/bs58": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
       "license": "MIT",
       "dependencies": {
         "base-x": "^3.0.2"
@@ -24479,6 +24723,8 @@
     },
     "node_modules/ganache-core/node_modules/bs58check": {
       "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
+      "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
       "license": "MIT",
       "dependencies": {
         "bs58": "^4.0.0",
@@ -24488,6 +24734,8 @@
     },
     "node_modules/ganache-core/node_modules/buffer": {
       "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
       "funding": [
         {
           "type": "github",
@@ -24514,15 +24762,21 @@
     },
     "node_modules/ganache-core/node_modules/buffer-to-arraybuffer": {
       "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/buffer-to-arraybuffer/-/buffer-to-arraybuffer-0.0.5.tgz",
+      "integrity": "sha1-YGSkD6dutDxyOrqe+PbhIW0QURo=",
       "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/buffer-xor": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/bufferutil": {
       "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.3.tgz",
+      "integrity": "sha512-yEYTwGndELGvfXsImMBLop58eaGW+YdONi1fNjTINSY98tmMmFijBG6WXgdkfuLNt4imzQNtIE+eBp1PVpMCSw==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -24531,6 +24785,8 @@
     },
     "node_modules/ganache-core/node_modules/bytes": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+      "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -24539,6 +24795,8 @@
     },
     "node_modules/ganache-core/node_modules/bytewise": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/bytewise/-/bytewise-1.1.0.tgz",
+      "integrity": "sha1-HRPL/3F65xWAlKqIGzXQgbOHJT4=",
       "license": "MIT",
       "dependencies": {
         "bytewise-core": "^1.2.2",
@@ -24547,6 +24805,8 @@
     },
     "node_modules/ganache-core/node_modules/bytewise-core": {
       "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/bytewise-core/-/bytewise-core-1.2.3.tgz",
+      "integrity": "sha1-P7QQx+kVWOsasiqCg0V3qmvWHUI=",
       "license": "MIT",
       "dependencies": {
         "typewise-core": "^1.2"
@@ -24554,6 +24814,8 @@
     },
     "node_modules/ganache-core/node_modules/cache-base": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "license": "MIT",
       "dependencies": {
         "collection-visit": "^1.0.0",
@@ -24572,6 +24834,8 @@
     },
     "node_modules/ganache-core/node_modules/cacheable-request": {
       "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
+      "integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -24589,6 +24853,8 @@
     },
     "node_modules/ganache-core/node_modules/cacheable-request/node_modules/lowercase-keys": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -24597,6 +24863,8 @@
     },
     "node_modules/ganache-core/node_modules/cachedown": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cachedown/-/cachedown-1.0.0.tgz",
+      "integrity": "sha1-1D8DbkUQaWsxJG19sx6/D3rDLRU=",
       "license": "MIT",
       "dependencies": {
         "abstract-leveldown": "^2.4.1",
@@ -24605,6 +24873,8 @@
     },
     "node_modules/ganache-core/node_modules/cachedown/node_modules/abstract-leveldown": {
       "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
+      "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
       "license": "MIT",
       "dependencies": {
         "xtend": "~4.0.0"
@@ -24612,6 +24882,8 @@
     },
     "node_modules/ganache-core/node_modules/cachedown/node_modules/lru-cache": {
       "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-3.2.0.tgz",
+      "integrity": "sha1-cXibO39Tmb7IVl3aOKow0qCX7+4=",
       "license": "ISC",
       "dependencies": {
         "pseudomap": "^1.0.1"
@@ -24619,6 +24891,8 @@
     },
     "node_modules/ganache-core/node_modules/call-bind": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.1",
@@ -24634,10 +24908,14 @@
     },
     "node_modules/ganache-core/node_modules/caseless": {
       "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "license": "Apache-2.0"
     },
     "node_modules/ganache-core/node_modules/chalk": {
       "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^3.2.1",
@@ -24650,6 +24928,8 @@
     },
     "node_modules/ganache-core/node_modules/checkpoint-store": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/checkpoint-store/-/checkpoint-store-1.1.0.tgz",
+      "integrity": "sha1-BOTLUWuRQziTWB5tRgGnjpVS6gY=",
       "license": "ISC",
       "dependencies": {
         "functional-red-black-tree": "^1.0.1"
@@ -24657,15 +24937,21 @@
     },
     "node_modules/ganache-core/node_modules/chownr": {
       "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "license": "ISC",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/ci-info": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/cids": {
       "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/cids/-/cids-0.7.5.tgz",
+      "integrity": "sha512-zT7mPeghoWAu+ppn8+BS1tQ5qGmbMfB4AregnQjA/qHY3GC1m1ptI9GkWNlgeu38r7CuRdXB47uY2XgAYt6QVA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -24682,6 +24968,8 @@
     },
     "node_modules/ganache-core/node_modules/cids/node_modules/multicodec": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
+      "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -24691,6 +24979,8 @@
     },
     "node_modules/ganache-core/node_modules/cipher-base": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.1",
@@ -24699,11 +24989,15 @@
     },
     "node_modules/ganache-core/node_modules/class-is": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/class-is/-/class-is-1.1.0.tgz",
+      "integrity": "sha512-rhjH9AG1fvabIDoGRVH587413LPjTZgmDF9fOFCbFJQV4yuocX1mHxxvXI4g3cGwbVY9wAYIoKlg1N79frJKQw==",
       "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/class-utils": {
       "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+      "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
       "license": "MIT",
       "dependencies": {
         "arr-union": "^3.1.0",
@@ -24717,6 +25011,8 @@
     },
     "node_modules/ganache-core/node_modules/class-utils/node_modules/define-property": {
       "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+      "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
       "license": "MIT",
       "dependencies": {
         "is-descriptor": "^0.1.0"
@@ -24727,6 +25023,8 @@
     },
     "node_modules/ganache-core/node_modules/class-utils/node_modules/is-accessor-descriptor": {
       "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "license": "MIT",
       "dependencies": {
         "kind-of": "^3.0.2"
@@ -24737,6 +25035,8 @@
     },
     "node_modules/ganache-core/node_modules/class-utils/node_modules/is-accessor-descriptor/node_modules/kind-of": {
       "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "license": "MIT",
       "dependencies": {
         "is-buffer": "^1.1.5"
@@ -24747,10 +25047,14 @@
     },
     "node_modules/ganache-core/node_modules/class-utils/node_modules/is-buffer": {
       "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/class-utils/node_modules/is-data-descriptor": {
       "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "license": "MIT",
       "dependencies": {
         "kind-of": "^3.0.2"
@@ -24761,6 +25065,8 @@
     },
     "node_modules/ganache-core/node_modules/class-utils/node_modules/is-data-descriptor/node_modules/kind-of": {
       "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "license": "MIT",
       "dependencies": {
         "is-buffer": "^1.1.5"
@@ -24771,6 +25077,8 @@
     },
     "node_modules/ganache-core/node_modules/class-utils/node_modules/is-descriptor": {
       "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
       "license": "MIT",
       "dependencies": {
         "is-accessor-descriptor": "^0.1.6",
@@ -24783,6 +25091,8 @@
     },
     "node_modules/ganache-core/node_modules/class-utils/node_modules/kind-of": {
       "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+      "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -24790,6 +25100,8 @@
     },
     "node_modules/ganache-core/node_modules/clone": {
       "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
       "license": "MIT",
       "engines": {
         "node": ">=0.8"
@@ -24797,6 +25109,8 @@
     },
     "node_modules/ganache-core/node_modules/clone-response": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
+      "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -24805,6 +25119,8 @@
     },
     "node_modules/ganache-core/node_modules/collection-visit": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "license": "MIT",
       "dependencies": {
         "map-visit": "^1.0.0",
@@ -24816,6 +25132,8 @@
     },
     "node_modules/ganache-core/node_modules/color-convert": {
       "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "license": "MIT",
       "dependencies": {
         "color-name": "1.1.3"
@@ -24823,10 +25141,14 @@
     },
     "node_modules/ganache-core/node_modules/color-name": {
       "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/combined-stream": {
       "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -24837,14 +25159,20 @@
     },
     "node_modules/ganache-core/node_modules/component-emitter": {
       "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/concat-map": {
       "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/concat-stream": {
       "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "engines": [
         "node >= 0.8"
       ],
@@ -24858,6 +25186,8 @@
     },
     "node_modules/ganache-core/node_modules/content-disposition": {
       "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
+      "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -24869,11 +25199,15 @@
     },
     "node_modules/ganache-core/node_modules/content-disposition/node_modules/safe-buffer": {
       "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/content-hash": {
       "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/content-hash/-/content-hash-2.5.2.tgz",
+      "integrity": "sha512-FvIQKy0S1JaWV10sMsA7TRx8bpU+pqPkhbsfvOJAdjRXvYxEckAwQWGwtRjiaJfh+E0DvcWUGqcdjwMGFjsSdw==",
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -24884,6 +25218,8 @@
     },
     "node_modules/ganache-core/node_modules/content-type": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -24899,10 +25235,14 @@
     },
     "node_modules/ganache-core/node_modules/convert-source-map/node_modules/safe-buffer": {
       "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/cookie": {
       "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+      "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -24911,16 +25251,22 @@
     },
     "node_modules/ganache-core/node_modules/cookie-signature": {
       "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
       "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/cookiejar": {
       "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
+      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==",
       "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/copy-descriptor": {
       "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -24928,6 +25274,8 @@
     },
     "node_modules/ganache-core/node_modules/core-js": {
       "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
       "hasInstallScript": true,
       "license": "MIT"
     },
@@ -24942,10 +25290,14 @@
     },
     "node_modules/ganache-core/node_modules/core-util-is": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/cors": {
       "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -24958,6 +25310,8 @@
     },
     "node_modules/ganache-core/node_modules/create-ecdh": {
       "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
+      "integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -24967,6 +25321,8 @@
     },
     "node_modules/ganache-core/node_modules/create-hash": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "license": "MIT",
       "dependencies": {
         "cipher-base": "^1.0.1",
@@ -24978,6 +25334,8 @@
     },
     "node_modules/ganache-core/node_modules/create-hmac": {
       "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "license": "MIT",
       "dependencies": {
         "cipher-base": "^1.0.3",
@@ -24998,6 +25356,8 @@
     },
     "node_modules/ganache-core/node_modules/crypto-browserify": {
       "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+      "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -25019,6 +25379,8 @@
     },
     "node_modules/ganache-core/node_modules/d": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
       "license": "ISC",
       "dependencies": {
         "es5-ext": "^0.10.50",
@@ -25027,6 +25389,8 @@
     },
     "node_modules/ganache-core/node_modules/dashdash": {
       "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "license": "MIT",
       "dependencies": {
         "assert-plus": "^1.0.0"
@@ -25037,6 +25401,8 @@
     },
     "node_modules/ganache-core/node_modules/debug": {
       "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
@@ -25044,6 +25410,8 @@
     },
     "node_modules/ganache-core/node_modules/decode-uri-component": {
       "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "license": "MIT",
       "engines": {
         "node": ">=0.10"
@@ -25051,6 +25419,8 @@
     },
     "node_modules/ganache-core/node_modules/decompress-response": {
       "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -25062,6 +25432,8 @@
     },
     "node_modules/ganache-core/node_modules/deep-equal": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
+      "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
       "license": "MIT",
       "dependencies": {
         "is-arguments": "^1.0.4",
@@ -25077,11 +25449,15 @@
     },
     "node_modules/ganache-core/node_modules/defer-to-connect": {
       "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
+      "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==",
       "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/deferred-leveldown": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-4.0.2.tgz",
+      "integrity": "sha512-5fMC8ek8alH16QiV0lTCis610D1Zt1+LA4MS4d63JgS32lrCjTFDUFz2ao09/j2I4Bqb5jL4FZYwu7Jz0XO1ww==",
       "license": "MIT",
       "dependencies": {
         "abstract-leveldown": "~5.0.0",
@@ -25093,6 +25469,8 @@
     },
     "node_modules/ganache-core/node_modules/deferred-leveldown/node_modules/abstract-leveldown": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-5.0.0.tgz",
+      "integrity": "sha512-5mU5P1gXtsMIXg65/rsYGsi93+MlogXZ9FA8JnwKurHQg64bfXwGYVdVdijNTVNOlAsuIiOwHdvFFD5JqCJQ7A==",
       "license": "MIT",
       "dependencies": {
         "xtend": "~4.0.0"
@@ -25103,6 +25481,8 @@
     },
     "node_modules/ganache-core/node_modules/define-properties": {
       "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
       "license": "MIT",
       "dependencies": {
         "object-keys": "^1.0.12"
@@ -25113,6 +25493,8 @@
     },
     "node_modules/ganache-core/node_modules/define-property": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+      "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
       "license": "MIT",
       "dependencies": {
         "is-descriptor": "^1.0.2",
@@ -25124,10 +25506,14 @@
     },
     "node_modules/ganache-core/node_modules/defined": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/delayed-stream": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -25135,6 +25521,8 @@
     },
     "node_modules/ganache-core/node_modules/depd": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -25143,6 +25531,8 @@
     },
     "node_modules/ganache-core/node_modules/des.js": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
+      "integrity": "sha512-Q0I4pfFrv2VPd34/vfLrFOoRmlYj3OV50i7fskps1jZWK1kApMWWT9G6RRUeYedLcBDIhnSDaUvJMb3AhUlaEA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -25152,11 +25542,15 @@
     },
     "node_modules/ganache-core/node_modules/destroy": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
       "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/detect-indent": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+      "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
       "license": "MIT",
       "dependencies": {
         "repeating": "^2.0.0"
@@ -25167,6 +25561,8 @@
     },
     "node_modules/ganache-core/node_modules/diffie-hellman": {
       "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -25176,10 +25572,14 @@
       }
     },
     "node_modules/ganache-core/node_modules/dom-walk": {
-      "version": "0.1.2"
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
+      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
     },
     "node_modules/ganache-core/node_modules/dotignore": {
       "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/dotignore/-/dotignore-0.1.2.tgz",
+      "integrity": "sha512-UGGGWfSauusaVJC+8fgV+NVvBXkCTmVv7sk6nojDZZvuOUNGUy0Zk4UpHQD6EDjS0jpBwcACvH4eofvyzBcRDw==",
       "license": "MIT",
       "dependencies": {
         "minimatch": "^3.0.4"
@@ -25190,11 +25590,15 @@
     },
     "node_modules/ganache-core/node_modules/duplexer3": {
       "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
       "license": "BSD-3-Clause",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/ecc-jsbn": {
       "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "license": "MIT",
       "dependencies": {
         "jsbn": "~0.1.0",
@@ -25203,6 +25607,8 @@
     },
     "node_modules/ganache-core/node_modules/ee-first": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
       "license": "MIT",
       "optional": true
     },
@@ -25225,6 +25631,8 @@
     },
     "node_modules/ganache-core/node_modules/encodeurl": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -25233,6 +25641,8 @@
     },
     "node_modules/ganache-core/node_modules/encoding": {
       "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
       "license": "MIT",
       "dependencies": {
         "iconv-lite": "^0.6.2"
@@ -25240,6 +25650,8 @@
     },
     "node_modules/ganache-core/node_modules/encoding-down": {
       "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-5.0.4.tgz",
+      "integrity": "sha512-8CIZLDcSKxgzT+zX8ZVfgNbu8Md2wq/iqa1Y7zyVR18QBEAc0Nmzuvj/N5ykSKpfGzjM8qxbaFntLPwnVoUhZw==",
       "license": "MIT",
       "dependencies": {
         "abstract-leveldown": "^5.0.0",
@@ -25254,6 +25666,8 @@
     },
     "node_modules/ganache-core/node_modules/encoding-down/node_modules/abstract-leveldown": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-5.0.0.tgz",
+      "integrity": "sha512-5mU5P1gXtsMIXg65/rsYGsi93+MlogXZ9FA8JnwKurHQg64bfXwGYVdVdijNTVNOlAsuIiOwHdvFFD5JqCJQ7A==",
       "license": "MIT",
       "dependencies": {
         "xtend": "~4.0.0"
@@ -25274,6 +25688,8 @@
     },
     "node_modules/ganache-core/node_modules/end-of-stream": {
       "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
@@ -25281,6 +25697,8 @@
     },
     "node_modules/ganache-core/node_modules/errno": {
       "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
+      "integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
       "license": "MIT",
       "dependencies": {
         "prr": "~1.0.1"
@@ -25315,6 +25733,8 @@
     },
     "node_modules/ganache-core/node_modules/es-to-primitive": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
       "license": "MIT",
       "dependencies": {
         "is-callable": "^1.1.4",
@@ -25330,6 +25750,8 @@
     },
     "node_modules/ganache-core/node_modules/es5-ext": {
       "version": "0.10.53",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
+      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
       "license": "ISC",
       "dependencies": {
         "es6-iterator": "~2.0.3",
@@ -25339,6 +25761,8 @@
     },
     "node_modules/ganache-core/node_modules/es6-iterator": {
       "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "license": "MIT",
       "dependencies": {
         "d": "1",
@@ -25348,6 +25772,8 @@
     },
     "node_modules/ganache-core/node_modules/es6-symbol": {
       "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
       "license": "ISC",
       "dependencies": {
         "d": "^1.0.1",
@@ -25356,11 +25782,15 @@
     },
     "node_modules/ganache-core/node_modules/escape-html": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
       "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/escape-string-regexp": {
       "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
@@ -25368,6 +25798,8 @@
     },
     "node_modules/ganache-core/node_modules/esutils": {
       "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -25375,6 +25807,8 @@
     },
     "node_modules/ganache-core/node_modules/etag": {
       "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -25383,6 +25817,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-block-tracker": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/eth-block-tracker/-/eth-block-tracker-3.0.1.tgz",
+      "integrity": "sha512-WUVxWLuhMmsfenfZvFO5sbl1qFY2IqUlw/FPVmjjdElpqLsZtSG+wPe9Dz7W/sB6e80HgFKknOmKk2eNlznHug==",
       "license": "MIT",
       "dependencies": {
         "eth-query": "^2.1.0",
@@ -25396,6 +25832,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-block-tracker/node_modules/ethereumjs-tx": {
       "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-1.3.7.tgz",
+      "integrity": "sha512-wvLMxzt1RPhAQ9Yi3/HKZTn0FZYpnsmQdbKYfUUpi4j1SEIcbkd9tndVjcPrufY3V7j2IebOpC00Zp2P/Ay2kA==",
       "license": "MPL-2.0",
       "dependencies": {
         "ethereum-common": "^0.0.18",
@@ -25404,6 +25842,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-block-tracker/node_modules/ethereumjs-util": {
       "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+      "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
       "license": "MPL-2.0",
       "dependencies": {
         "bn.js": "^4.11.0",
@@ -25417,6 +25857,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-block-tracker/node_modules/pify": {
       "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -25424,6 +25866,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-ens-namehash": {
       "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/eth-ens-namehash/-/eth-ens-namehash-2.0.8.tgz",
+      "integrity": "sha1-IprEbsqG1S4MmR58sq74P/D2i88=",
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -25433,6 +25877,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-json-rpc-infura": {
       "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/eth-json-rpc-infura/-/eth-json-rpc-infura-3.2.1.tgz",
+      "integrity": "sha512-W7zR4DZvyTn23Bxc0EWsq4XGDdD63+XPUCEhV2zQvQGavDVC4ZpFDK4k99qN7bd7/fjj37+rxmuBOBeIqCA5Mw==",
       "license": "ISC",
       "dependencies": {
         "cross-fetch": "^2.1.1",
@@ -25443,6 +25889,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-json-rpc-middleware": {
       "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/eth-json-rpc-middleware/-/eth-json-rpc-middleware-1.6.0.tgz",
+      "integrity": "sha512-tDVCTlrUvdqHKqivYMjtFZsdD7TtpNLBCfKAcOpaVs7orBMS/A8HWro6dIzNtTZIR05FAbJ3bioFOnZpuCew9Q==",
       "license": "ISC",
       "dependencies": {
         "async": "^2.5.0",
@@ -25462,6 +25910,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-json-rpc-middleware/node_modules/abstract-leveldown": {
       "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
+      "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
       "license": "MIT",
       "dependencies": {
         "xtend": "~4.0.0"
@@ -25469,6 +25919,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-json-rpc-middleware/node_modules/deferred-leveldown": {
       "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz",
+      "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
       "license": "MIT",
       "dependencies": {
         "abstract-leveldown": "~2.6.0"
@@ -25476,6 +25928,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-json-rpc-middleware/node_modules/ethereumjs-account": {
       "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/ethereumjs-account/-/ethereumjs-account-2.0.5.tgz",
+      "integrity": "sha512-bgDojnXGjhMwo6eXQC0bY6UK2liSFUSMwwylOmQvZbSl/D7NXQ3+vrGO46ZeOgjGfxXmgIeVNDIiHw7fNZM4VA==",
       "license": "MPL-2.0",
       "dependencies": {
         "ethereumjs-util": "^5.0.0",
@@ -25485,6 +25939,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-json-rpc-middleware/node_modules/ethereumjs-block": {
       "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.7.1.tgz",
+      "integrity": "sha512-B+sSdtqm78fmKkBq78/QLKJbu/4Ts4P2KFISdgcuZUPDm9x+N7qgBPIIFUGbaakQh8bzuquiRVbdmvPKqbILRg==",
       "license": "MPL-2.0",
       "dependencies": {
         "async": "^2.0.1",
@@ -25496,10 +25952,14 @@
     },
     "node_modules/ganache-core/node_modules/eth-json-rpc-middleware/node_modules/ethereumjs-block/node_modules/ethereum-common": {
       "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.2.0.tgz",
+      "integrity": "sha512-XOnAR/3rntJgbCdGhqdaLIxDLWKLmsZOGhHdBKadEr6gEnJLH52k93Ou+TUdFaPN3hJc3isBZBal3U/XZ15abA==",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/eth-json-rpc-middleware/node_modules/ethereumjs-tx": {
       "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-1.3.7.tgz",
+      "integrity": "sha512-wvLMxzt1RPhAQ9Yi3/HKZTn0FZYpnsmQdbKYfUUpi4j1SEIcbkd9tndVjcPrufY3V7j2IebOpC00Zp2P/Ay2kA==",
       "license": "MPL-2.0",
       "dependencies": {
         "ethereum-common": "^0.0.18",
@@ -25508,6 +25968,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-json-rpc-middleware/node_modules/ethereumjs-util": {
       "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+      "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
       "license": "MPL-2.0",
       "dependencies": {
         "bn.js": "^4.11.0",
@@ -25521,6 +25983,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-json-rpc-middleware/node_modules/ethereumjs-vm": {
       "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-2.6.0.tgz",
+      "integrity": "sha512-r/XIUik/ynGbxS3y+mvGnbOKnuLo40V5Mj1J25+HEO63aWYREIqvWeRO/hnROlMBE5WoniQmPmhiaN0ctiHaXw==",
       "license": "MPL-2.0",
       "dependencies": {
         "async": "^2.1.2",
@@ -25538,6 +26002,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-json-rpc-middleware/node_modules/ethereumjs-vm/node_modules/ethereumjs-block": {
       "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-2.2.2.tgz",
+      "integrity": "sha512-2p49ifhek3h2zeg/+da6XpdFR3GlqY3BIEiqxGF8j9aSRIgkb7M1Ky+yULBKJOu8PAZxfhsYA+HxUk2aCQp3vg==",
       "license": "MPL-2.0",
       "dependencies": {
         "async": "^2.0.1",
@@ -25549,6 +26015,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-json-rpc-middleware/node_modules/ethereumjs-vm/node_modules/ethereumjs-block/node_modules/ethereumjs-util": {
       "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+      "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
       "license": "MPL-2.0",
       "dependencies": {
         "bn.js": "^4.11.0",
@@ -25562,6 +26030,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-json-rpc-middleware/node_modules/ethereumjs-vm/node_modules/ethereumjs-tx": {
       "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-2.1.2.tgz",
+      "integrity": "sha512-zZEK1onCeiORb0wyCXUvg94Ve5It/K6GD1K+26KfFKodiBiS6d9lfCXlUKGBBdQ+bv7Day+JK0tj1K+BeNFRAw==",
       "license": "MPL-2.0",
       "dependencies": {
         "ethereumjs-common": "^1.5.0",
@@ -25570,6 +26040,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-json-rpc-middleware/node_modules/ethereumjs-vm/node_modules/ethereumjs-util": {
       "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
+      "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
       "license": "MPL-2.0",
       "dependencies": {
         "@types/bn.js": "^4.11.3",
@@ -25583,14 +26055,20 @@
     },
     "node_modules/ganache-core/node_modules/eth-json-rpc-middleware/node_modules/isarray": {
       "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/eth-json-rpc-middleware/node_modules/level-codec": {
       "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-7.0.1.tgz",
+      "integrity": "sha512-Ua/R9B9r3RasXdRmOtd+t9TCOEIIlts+TN/7XTT2unhDaL6sJn83S3rUyljbr6lVtw49N3/yA0HHjpV6Kzb2aQ==",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/eth-json-rpc-middleware/node_modules/level-errors": {
       "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.5.tgz",
+      "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
       "license": "MIT",
       "dependencies": {
         "errno": "~0.1.1"
@@ -25598,6 +26076,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-json-rpc-middleware/node_modules/level-iterator-stream": {
       "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
+      "integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.1",
@@ -25608,6 +26088,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-json-rpc-middleware/node_modules/level-iterator-stream/node_modules/readable-stream": {
       "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -25618,6 +26100,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-json-rpc-middleware/node_modules/level-ws": {
       "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/level-ws/-/level-ws-0.0.0.tgz",
+      "integrity": "sha1-Ny5RIXeSSgBCSwtDrvK7QkltIos=",
       "license": "MIT",
       "dependencies": {
         "readable-stream": "~1.0.15",
@@ -25626,6 +26110,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-json-rpc-middleware/node_modules/level-ws/node_modules/readable-stream": {
       "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -25636,6 +26122,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-json-rpc-middleware/node_modules/level-ws/node_modules/xtend": {
       "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+      "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
       "dependencies": {
         "object-keys": "~0.4.0"
       },
@@ -25645,6 +26133,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-json-rpc-middleware/node_modules/levelup": {
       "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.9.tgz",
+      "integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
       "license": "MIT",
       "dependencies": {
         "deferred-leveldown": "~1.2.1",
@@ -25658,10 +26148,14 @@
     },
     "node_modules/ganache-core/node_modules/eth-json-rpc-middleware/node_modules/ltgt": {
       "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
+      "integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/eth-json-rpc-middleware/node_modules/memdown": {
       "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/memdown/-/memdown-1.4.1.tgz",
+      "integrity": "sha1-tOThkhdGZP+65BNhqlAPMRnv4hU=",
       "license": "MIT",
       "dependencies": {
         "abstract-leveldown": "~2.7.1",
@@ -25674,6 +26168,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-json-rpc-middleware/node_modules/memdown/node_modules/abstract-leveldown": {
       "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
+      "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
       "license": "MIT",
       "dependencies": {
         "xtend": "~4.0.0"
@@ -25681,6 +26177,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-json-rpc-middleware/node_modules/merkle-patricia-tree": {
       "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-2.3.2.tgz",
+      "integrity": "sha512-81PW5m8oz/pz3GvsAwbauj7Y00rqm81Tzad77tHBwU7pIAtN+TJnMSOJhxBKflSVYhptMMb9RskhqHqrSm1V+g==",
       "license": "MPL-2.0",
       "dependencies": {
         "async": "^1.4.2",
@@ -25695,18 +26193,26 @@
     },
     "node_modules/ganache-core/node_modules/eth-json-rpc-middleware/node_modules/merkle-patricia-tree/node_modules/async": {
       "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/eth-json-rpc-middleware/node_modules/object-keys": {
       "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+      "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/eth-json-rpc-middleware/node_modules/safe-buffer": {
       "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/eth-json-rpc-middleware/node_modules/semver": {
       "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver"
@@ -25714,10 +26220,14 @@
     },
     "node_modules/ganache-core/node_modules/eth-json-rpc-middleware/node_modules/string_decoder": {
       "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/eth-lib": {
       "version": "0.1.29",
+      "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.1.29.tgz",
+      "integrity": "sha512-bfttrr3/7gG4E02HoWTDUcDDslN003OlOoBxk9virpAZQ1ja/jDgwkWB8QfJF7ojuEowrqy+lzp9VcJG7/k5bQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -25731,6 +26241,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-query": {
       "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/eth-query/-/eth-query-2.1.2.tgz",
+      "integrity": "sha1-1nQdkAAQa1FRDHLbktY2VFam2l4=",
       "license": "ISC",
       "dependencies": {
         "json-rpc-random-id": "^1.0.0",
@@ -25739,6 +26251,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-sig-util": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-3.0.0.tgz",
+      "integrity": "sha512-4eFkMOhpGbTxBQ3AMzVf0haUX2uTur7DpWiHzWyTURa28BVJJtOkcb9Ok5TV0YvEPG61DODPW7ZUATbJTslioQ==",
       "license": "ISC",
       "dependencies": {
         "buffer": "^5.2.1",
@@ -25751,6 +26265,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-sig-util/node_modules/ethereumjs-abi": {
       "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/ethereumjs-abi/-/ethereumjs-abi-0.6.5.tgz",
+      "integrity": "sha1-WmN+8Wq0NHP6cqKa2QhxQFs/UkE=",
       "license": "MIT",
       "dependencies": {
         "bn.js": "^4.10.0",
@@ -25759,6 +26275,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-sig-util/node_modules/ethereumjs-abi/node_modules/ethereumjs-util": {
       "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.1.tgz",
+      "integrity": "sha512-WrckOZ7uBnei4+AKimpuF1B3Fv25OmoRgmYCpGsP7u8PFxXAmAgiJSYT2kRWnt6fVIlKaQlZvuwXp7PIrmn3/w==",
       "license": "MPL-2.0",
       "dependencies": {
         "bn.js": "^4.8.0",
@@ -25770,6 +26288,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-sig-util/node_modules/ethereumjs-util": {
       "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+      "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
       "license": "MPL-2.0",
       "dependencies": {
         "bn.js": "^4.11.0",
@@ -25783,6 +26303,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-tx-summary": {
       "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/eth-tx-summary/-/eth-tx-summary-3.2.4.tgz",
+      "integrity": "sha512-NtlDnaVZah146Rm8HMRUNMgIwG/ED4jiqk0TME9zFheMl1jOp6jL1m0NKGjJwehXQ6ZKCPr16MTr+qspKpEXNg==",
       "license": "ISC",
       "dependencies": {
         "async": "^2.1.2",
@@ -25799,6 +26321,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-tx-summary/node_modules/abstract-leveldown": {
       "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
+      "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
       "license": "MIT",
       "dependencies": {
         "xtend": "~4.0.0"
@@ -25806,6 +26330,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-tx-summary/node_modules/deferred-leveldown": {
       "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz",
+      "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
       "license": "MIT",
       "dependencies": {
         "abstract-leveldown": "~2.6.0"
@@ -25813,6 +26339,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-tx-summary/node_modules/ethereumjs-account": {
       "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/ethereumjs-account/-/ethereumjs-account-2.0.5.tgz",
+      "integrity": "sha512-bgDojnXGjhMwo6eXQC0bY6UK2liSFUSMwwylOmQvZbSl/D7NXQ3+vrGO46ZeOgjGfxXmgIeVNDIiHw7fNZM4VA==",
       "license": "MPL-2.0",
       "dependencies": {
         "ethereumjs-util": "^5.0.0",
@@ -25822,6 +26350,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-tx-summary/node_modules/ethereumjs-block": {
       "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.7.1.tgz",
+      "integrity": "sha512-B+sSdtqm78fmKkBq78/QLKJbu/4Ts4P2KFISdgcuZUPDm9x+N7qgBPIIFUGbaakQh8bzuquiRVbdmvPKqbILRg==",
       "license": "MPL-2.0",
       "dependencies": {
         "async": "^2.0.1",
@@ -25833,10 +26363,14 @@
     },
     "node_modules/ganache-core/node_modules/eth-tx-summary/node_modules/ethereumjs-block/node_modules/ethereum-common": {
       "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.2.0.tgz",
+      "integrity": "sha512-XOnAR/3rntJgbCdGhqdaLIxDLWKLmsZOGhHdBKadEr6gEnJLH52k93Ou+TUdFaPN3hJc3isBZBal3U/XZ15abA==",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/eth-tx-summary/node_modules/ethereumjs-tx": {
       "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-1.3.7.tgz",
+      "integrity": "sha512-wvLMxzt1RPhAQ9Yi3/HKZTn0FZYpnsmQdbKYfUUpi4j1SEIcbkd9tndVjcPrufY3V7j2IebOpC00Zp2P/Ay2kA==",
       "license": "MPL-2.0",
       "dependencies": {
         "ethereum-common": "^0.0.18",
@@ -25845,6 +26379,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-tx-summary/node_modules/ethereumjs-util": {
       "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+      "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
       "license": "MPL-2.0",
       "dependencies": {
         "bn.js": "^4.11.0",
@@ -25858,6 +26394,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-tx-summary/node_modules/ethereumjs-vm": {
       "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-2.6.0.tgz",
+      "integrity": "sha512-r/XIUik/ynGbxS3y+mvGnbOKnuLo40V5Mj1J25+HEO63aWYREIqvWeRO/hnROlMBE5WoniQmPmhiaN0ctiHaXw==",
       "license": "MPL-2.0",
       "dependencies": {
         "async": "^2.1.2",
@@ -25875,6 +26413,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-tx-summary/node_modules/ethereumjs-vm/node_modules/ethereumjs-block": {
       "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-2.2.2.tgz",
+      "integrity": "sha512-2p49ifhek3h2zeg/+da6XpdFR3GlqY3BIEiqxGF8j9aSRIgkb7M1Ky+yULBKJOu8PAZxfhsYA+HxUk2aCQp3vg==",
       "license": "MPL-2.0",
       "dependencies": {
         "async": "^2.0.1",
@@ -25886,6 +26426,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-tx-summary/node_modules/ethereumjs-vm/node_modules/ethereumjs-block/node_modules/ethereumjs-util": {
       "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+      "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
       "license": "MPL-2.0",
       "dependencies": {
         "bn.js": "^4.11.0",
@@ -25899,6 +26441,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-tx-summary/node_modules/ethereumjs-vm/node_modules/ethereumjs-tx": {
       "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-2.1.2.tgz",
+      "integrity": "sha512-zZEK1onCeiORb0wyCXUvg94Ve5It/K6GD1K+26KfFKodiBiS6d9lfCXlUKGBBdQ+bv7Day+JK0tj1K+BeNFRAw==",
       "license": "MPL-2.0",
       "dependencies": {
         "ethereumjs-common": "^1.5.0",
@@ -25907,6 +26451,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-tx-summary/node_modules/ethereumjs-vm/node_modules/ethereumjs-util": {
       "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
+      "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
       "license": "MPL-2.0",
       "dependencies": {
         "@types/bn.js": "^4.11.3",
@@ -25920,14 +26466,20 @@
     },
     "node_modules/ganache-core/node_modules/eth-tx-summary/node_modules/isarray": {
       "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/eth-tx-summary/node_modules/level-codec": {
       "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-7.0.1.tgz",
+      "integrity": "sha512-Ua/R9B9r3RasXdRmOtd+t9TCOEIIlts+TN/7XTT2unhDaL6sJn83S3rUyljbr6lVtw49N3/yA0HHjpV6Kzb2aQ==",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/eth-tx-summary/node_modules/level-errors": {
       "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.5.tgz",
+      "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
       "license": "MIT",
       "dependencies": {
         "errno": "~0.1.1"
@@ -25935,6 +26487,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-tx-summary/node_modules/level-iterator-stream": {
       "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
+      "integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.1",
@@ -25945,6 +26499,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-tx-summary/node_modules/level-iterator-stream/node_modules/readable-stream": {
       "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -25955,6 +26511,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-tx-summary/node_modules/level-ws": {
       "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/level-ws/-/level-ws-0.0.0.tgz",
+      "integrity": "sha1-Ny5RIXeSSgBCSwtDrvK7QkltIos=",
       "license": "MIT",
       "dependencies": {
         "readable-stream": "~1.0.15",
@@ -25963,6 +26521,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-tx-summary/node_modules/level-ws/node_modules/readable-stream": {
       "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -25973,6 +26533,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-tx-summary/node_modules/level-ws/node_modules/xtend": {
       "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+      "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
       "dependencies": {
         "object-keys": "~0.4.0"
       },
@@ -25982,6 +26544,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-tx-summary/node_modules/levelup": {
       "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.9.tgz",
+      "integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
       "license": "MIT",
       "dependencies": {
         "deferred-leveldown": "~1.2.1",
@@ -25995,10 +26559,14 @@
     },
     "node_modules/ganache-core/node_modules/eth-tx-summary/node_modules/ltgt": {
       "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
+      "integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/eth-tx-summary/node_modules/memdown": {
       "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/memdown/-/memdown-1.4.1.tgz",
+      "integrity": "sha1-tOThkhdGZP+65BNhqlAPMRnv4hU=",
       "license": "MIT",
       "dependencies": {
         "abstract-leveldown": "~2.7.1",
@@ -26011,6 +26579,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-tx-summary/node_modules/memdown/node_modules/abstract-leveldown": {
       "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
+      "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
       "license": "MIT",
       "dependencies": {
         "xtend": "~4.0.0"
@@ -26018,6 +26588,8 @@
     },
     "node_modules/ganache-core/node_modules/eth-tx-summary/node_modules/merkle-patricia-tree": {
       "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-2.3.2.tgz",
+      "integrity": "sha512-81PW5m8oz/pz3GvsAwbauj7Y00rqm81Tzad77tHBwU7pIAtN+TJnMSOJhxBKflSVYhptMMb9RskhqHqrSm1V+g==",
       "license": "MPL-2.0",
       "dependencies": {
         "async": "^1.4.2",
@@ -26032,18 +26604,26 @@
     },
     "node_modules/ganache-core/node_modules/eth-tx-summary/node_modules/merkle-patricia-tree/node_modules/async": {
       "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/eth-tx-summary/node_modules/object-keys": {
       "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+      "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/eth-tx-summary/node_modules/safe-buffer": {
       "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/eth-tx-summary/node_modules/semver": {
       "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver"
@@ -26051,10 +26631,14 @@
     },
     "node_modules/ganache-core/node_modules/eth-tx-summary/node_modules/string_decoder": {
       "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/ethashjs": {
       "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/ethashjs/-/ethashjs-0.0.8.tgz",
+      "integrity": "sha512-/MSbf/r2/Ld8o0l15AymjOTlPqpN8Cr4ByUEA9GtR4x0yAh3TdtDzEg29zMjXCNPI7u6E5fOQdj/Cf9Tc7oVNw==",
       "license": "MPL-2.0",
       "dependencies": {
         "async": "^2.1.2",
@@ -26069,6 +26653,8 @@
     },
     "node_modules/ganache-core/node_modules/ethashjs/node_modules/buffer-xor": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-2.0.2.tgz",
+      "integrity": "sha512-eHslX0bin3GB+Lx2p7lEYRShRewuNZL3fUl4qlVJGGiwoPGftmt8JQgk2Y9Ji5/01TnVDo33E5b5O3vUB1HdqQ==",
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "^5.1.1"
@@ -26099,15 +26685,21 @@
     },
     "node_modules/ganache-core/node_modules/ethereum-bloom-filters/node_modules/js-sha3": {
       "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
       "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/ethereum-common": {
       "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.18.tgz",
+      "integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/ethereum-cryptography": {
       "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
+      "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
       "license": "MIT",
       "dependencies": {
         "@types/pbkdf2": "^3.0.0",
@@ -26129,6 +26721,8 @@
     },
     "node_modules/ganache-core/node_modules/ethereumjs-abi": {
       "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/ethereumjs-abi/-/ethereumjs-abi-0.6.8.tgz",
+      "integrity": "sha512-Tx0r/iXI6r+lRsdvkFDlut0N08jWMnKRZ6Gkq+Nmw75lZe4e6o3EkSnkaBP5NF6+m5PTGAr9JP43N3LyeoglsA==",
       "license": "MIT",
       "dependencies": {
         "bn.js": "^4.11.8",
@@ -26137,6 +26731,8 @@
     },
     "node_modules/ganache-core/node_modules/ethereumjs-account": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ethereumjs-account/-/ethereumjs-account-3.0.0.tgz",
+      "integrity": "sha512-WP6BdscjiiPkQfF9PVfMcwx/rDvfZTjFKY0Uwc09zSQr9JfIVH87dYIJu0gNhBhpmovV4yq295fdllS925fnBA==",
       "license": "MPL-2.0",
       "dependencies": {
         "ethereumjs-util": "^6.0.0",
@@ -26146,6 +26742,8 @@
     },
     "node_modules/ganache-core/node_modules/ethereumjs-block": {
       "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-2.2.2.tgz",
+      "integrity": "sha512-2p49ifhek3h2zeg/+da6XpdFR3GlqY3BIEiqxGF8j9aSRIgkb7M1Ky+yULBKJOu8PAZxfhsYA+HxUk2aCQp3vg==",
       "license": "MPL-2.0",
       "dependencies": {
         "async": "^2.0.1",
@@ -26157,6 +26755,8 @@
     },
     "node_modules/ganache-core/node_modules/ethereumjs-block/node_modules/abstract-leveldown": {
       "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
+      "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
       "license": "MIT",
       "dependencies": {
         "xtend": "~4.0.0"
@@ -26164,6 +26764,8 @@
     },
     "node_modules/ganache-core/node_modules/ethereumjs-block/node_modules/deferred-leveldown": {
       "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz",
+      "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
       "license": "MIT",
       "dependencies": {
         "abstract-leveldown": "~2.6.0"
@@ -26171,6 +26773,8 @@
     },
     "node_modules/ganache-core/node_modules/ethereumjs-block/node_modules/ethereumjs-util": {
       "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+      "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
       "license": "MPL-2.0",
       "dependencies": {
         "bn.js": "^4.11.0",
@@ -26184,14 +26788,20 @@
     },
     "node_modules/ganache-core/node_modules/ethereumjs-block/node_modules/isarray": {
       "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/ethereumjs-block/node_modules/level-codec": {
       "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-7.0.1.tgz",
+      "integrity": "sha512-Ua/R9B9r3RasXdRmOtd+t9TCOEIIlts+TN/7XTT2unhDaL6sJn83S3rUyljbr6lVtw49N3/yA0HHjpV6Kzb2aQ==",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/ethereumjs-block/node_modules/level-errors": {
       "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.5.tgz",
+      "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
       "license": "MIT",
       "dependencies": {
         "errno": "~0.1.1"
@@ -26199,6 +26809,8 @@
     },
     "node_modules/ganache-core/node_modules/ethereumjs-block/node_modules/level-iterator-stream": {
       "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
+      "integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.1",
@@ -26209,6 +26821,8 @@
     },
     "node_modules/ganache-core/node_modules/ethereumjs-block/node_modules/level-iterator-stream/node_modules/readable-stream": {
       "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -26219,6 +26833,8 @@
     },
     "node_modules/ganache-core/node_modules/ethereumjs-block/node_modules/level-ws": {
       "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/level-ws/-/level-ws-0.0.0.tgz",
+      "integrity": "sha1-Ny5RIXeSSgBCSwtDrvK7QkltIos=",
       "license": "MIT",
       "dependencies": {
         "readable-stream": "~1.0.15",
@@ -26227,6 +26843,8 @@
     },
     "node_modules/ganache-core/node_modules/ethereumjs-block/node_modules/level-ws/node_modules/readable-stream": {
       "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -26237,6 +26855,8 @@
     },
     "node_modules/ganache-core/node_modules/ethereumjs-block/node_modules/level-ws/node_modules/xtend": {
       "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+      "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
       "dependencies": {
         "object-keys": "~0.4.0"
       },
@@ -26246,6 +26866,8 @@
     },
     "node_modules/ganache-core/node_modules/ethereumjs-block/node_modules/levelup": {
       "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.9.tgz",
+      "integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
       "license": "MIT",
       "dependencies": {
         "deferred-leveldown": "~1.2.1",
@@ -26259,10 +26881,14 @@
     },
     "node_modules/ganache-core/node_modules/ethereumjs-block/node_modules/ltgt": {
       "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
+      "integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/ethereumjs-block/node_modules/memdown": {
       "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/memdown/-/memdown-1.4.1.tgz",
+      "integrity": "sha1-tOThkhdGZP+65BNhqlAPMRnv4hU=",
       "license": "MIT",
       "dependencies": {
         "abstract-leveldown": "~2.7.1",
@@ -26275,6 +26901,8 @@
     },
     "node_modules/ganache-core/node_modules/ethereumjs-block/node_modules/memdown/node_modules/abstract-leveldown": {
       "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
+      "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
       "license": "MIT",
       "dependencies": {
         "xtend": "~4.0.0"
@@ -26282,6 +26910,8 @@
     },
     "node_modules/ganache-core/node_modules/ethereumjs-block/node_modules/merkle-patricia-tree": {
       "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-2.3.2.tgz",
+      "integrity": "sha512-81PW5m8oz/pz3GvsAwbauj7Y00rqm81Tzad77tHBwU7pIAtN+TJnMSOJhxBKflSVYhptMMb9RskhqHqrSm1V+g==",
       "license": "MPL-2.0",
       "dependencies": {
         "async": "^1.4.2",
@@ -26296,18 +26926,26 @@
     },
     "node_modules/ganache-core/node_modules/ethereumjs-block/node_modules/merkle-patricia-tree/node_modules/async": {
       "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/ethereumjs-block/node_modules/object-keys": {
       "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+      "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/ethereumjs-block/node_modules/safe-buffer": {
       "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/ethereumjs-block/node_modules/semver": {
       "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver"
@@ -26315,10 +26953,14 @@
     },
     "node_modules/ganache-core/node_modules/ethereumjs-block/node_modules/string_decoder": {
       "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/ethereumjs-blockchain": {
       "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/ethereumjs-blockchain/-/ethereumjs-blockchain-4.0.4.tgz",
+      "integrity": "sha512-zCxaRMUOzzjvX78DTGiKjA+4h2/sF0OYL1QuPux0DHpyq8XiNoF5GYHtb++GUxVlMsMfZV7AVyzbtgcRdIcEPQ==",
       "license": "MPL-2.0",
       "dependencies": {
         "async": "^2.6.1",
@@ -26335,10 +26977,14 @@
     },
     "node_modules/ganache-core/node_modules/ethereumjs-common": {
       "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/ethereumjs-common/-/ethereumjs-common-1.5.0.tgz",
+      "integrity": "sha512-SZOjgK1356hIY7MRj3/ma5qtfr/4B5BL+G4rP/XSMYr2z1H5el4RX5GReYCKmQmYI/nSBmRnwrZ17IfHuG0viQ==",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/ethereumjs-tx": {
       "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-2.1.2.tgz",
+      "integrity": "sha512-zZEK1onCeiORb0wyCXUvg94Ve5It/K6GD1K+26KfFKodiBiS6d9lfCXlUKGBBdQ+bv7Day+JK0tj1K+BeNFRAw==",
       "license": "MPL-2.0",
       "dependencies": {
         "ethereumjs-common": "^1.5.0",
@@ -26347,6 +26993,8 @@
     },
     "node_modules/ganache-core/node_modules/ethereumjs-util": {
       "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
+      "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
       "license": "MPL-2.0",
       "dependencies": {
         "@types/bn.js": "^4.11.3",
@@ -26360,6 +27008,8 @@
     },
     "node_modules/ganache-core/node_modules/ethereumjs-vm": {
       "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-4.2.0.tgz",
+      "integrity": "sha512-X6qqZbsY33p5FTuZqCnQ4+lo957iUJMM6Mpa6bL4UW0dxM6WmDSHuI4j/zOp1E2TDKImBGCJA9QPfc08PaNubA==",
       "license": "MPL-2.0",
       "dependencies": {
         "async": "^2.1.2",
@@ -26381,6 +27031,8 @@
     },
     "node_modules/ganache-core/node_modules/ethereumjs-vm/node_modules/abstract-leveldown": {
       "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
+      "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
       "license": "MIT",
       "dependencies": {
         "xtend": "~4.0.0"
@@ -26388,6 +27040,8 @@
     },
     "node_modules/ganache-core/node_modules/ethereumjs-vm/node_modules/deferred-leveldown": {
       "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz",
+      "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
       "license": "MIT",
       "dependencies": {
         "abstract-leveldown": "~2.6.0"
@@ -26395,14 +27049,20 @@
     },
     "node_modules/ganache-core/node_modules/ethereumjs-vm/node_modules/isarray": {
       "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/ethereumjs-vm/node_modules/level-codec": {
       "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-7.0.1.tgz",
+      "integrity": "sha512-Ua/R9B9r3RasXdRmOtd+t9TCOEIIlts+TN/7XTT2unhDaL6sJn83S3rUyljbr6lVtw49N3/yA0HHjpV6Kzb2aQ==",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/ethereumjs-vm/node_modules/level-errors": {
       "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.5.tgz",
+      "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
       "license": "MIT",
       "dependencies": {
         "errno": "~0.1.1"
@@ -26410,6 +27070,8 @@
     },
     "node_modules/ganache-core/node_modules/ethereumjs-vm/node_modules/level-iterator-stream": {
       "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
+      "integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.1",
@@ -26420,6 +27082,8 @@
     },
     "node_modules/ganache-core/node_modules/ethereumjs-vm/node_modules/level-iterator-stream/node_modules/readable-stream": {
       "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -26430,6 +27094,8 @@
     },
     "node_modules/ganache-core/node_modules/ethereumjs-vm/node_modules/level-ws": {
       "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/level-ws/-/level-ws-0.0.0.tgz",
+      "integrity": "sha1-Ny5RIXeSSgBCSwtDrvK7QkltIos=",
       "license": "MIT",
       "dependencies": {
         "readable-stream": "~1.0.15",
@@ -26438,6 +27104,8 @@
     },
     "node_modules/ganache-core/node_modules/ethereumjs-vm/node_modules/level-ws/node_modules/readable-stream": {
       "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -26448,6 +27116,8 @@
     },
     "node_modules/ganache-core/node_modules/ethereumjs-vm/node_modules/level-ws/node_modules/xtend": {
       "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+      "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
       "dependencies": {
         "object-keys": "~0.4.0"
       },
@@ -26457,6 +27127,8 @@
     },
     "node_modules/ganache-core/node_modules/ethereumjs-vm/node_modules/levelup": {
       "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.9.tgz",
+      "integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
       "license": "MIT",
       "dependencies": {
         "deferred-leveldown": "~1.2.1",
@@ -26470,10 +27142,14 @@
     },
     "node_modules/ganache-core/node_modules/ethereumjs-vm/node_modules/ltgt": {
       "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
+      "integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/ethereumjs-vm/node_modules/memdown": {
       "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/memdown/-/memdown-1.4.1.tgz",
+      "integrity": "sha1-tOThkhdGZP+65BNhqlAPMRnv4hU=",
       "license": "MIT",
       "dependencies": {
         "abstract-leveldown": "~2.7.1",
@@ -26486,6 +27162,8 @@
     },
     "node_modules/ganache-core/node_modules/ethereumjs-vm/node_modules/memdown/node_modules/abstract-leveldown": {
       "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
+      "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
       "license": "MIT",
       "dependencies": {
         "xtend": "~4.0.0"
@@ -26493,6 +27171,8 @@
     },
     "node_modules/ganache-core/node_modules/ethereumjs-vm/node_modules/merkle-patricia-tree": {
       "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-2.3.2.tgz",
+      "integrity": "sha512-81PW5m8oz/pz3GvsAwbauj7Y00rqm81Tzad77tHBwU7pIAtN+TJnMSOJhxBKflSVYhptMMb9RskhqHqrSm1V+g==",
       "license": "MPL-2.0",
       "dependencies": {
         "async": "^1.4.2",
@@ -26507,10 +27187,14 @@
     },
     "node_modules/ganache-core/node_modules/ethereumjs-vm/node_modules/merkle-patricia-tree/node_modules/async": {
       "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/ethereumjs-vm/node_modules/merkle-patricia-tree/node_modules/ethereumjs-util": {
       "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+      "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
       "license": "MPL-2.0",
       "dependencies": {
         "bn.js": "^4.11.0",
@@ -26524,14 +27208,20 @@
     },
     "node_modules/ganache-core/node_modules/ethereumjs-vm/node_modules/object-keys": {
       "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+      "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/ethereumjs-vm/node_modules/safe-buffer": {
       "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/ethereumjs-vm/node_modules/semver": {
       "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver"
@@ -26539,10 +27229,14 @@
     },
     "node_modules/ganache-core/node_modules/ethereumjs-vm/node_modules/string_decoder": {
       "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/ethereumjs-wallet": {
       "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/ethereumjs-wallet/-/ethereumjs-wallet-0.6.5.tgz",
+      "integrity": "sha512-MDwjwB9VQVnpp/Dc1XzA6J1a3wgHQ4hSvA1uWNatdpOrtCbPVuQSKSyRnjLvS0a+KKMw2pvQ9Ybqpb3+eW8oNA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -26559,6 +27253,8 @@
     },
     "node_modules/ganache-core/node_modules/ethjs-unit": {
       "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/ethjs-unit/-/ethjs-unit-0.1.6.tgz",
+      "integrity": "sha1-xmWSHkduh7ziqdWIpv4EBbLEFpk=",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -26572,11 +27268,15 @@
     },
     "node_modules/ganache-core/node_modules/ethjs-unit/node_modules/bn.js": {
       "version": "4.11.6",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+      "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
       "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/ethjs-util": {
       "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.6.tgz",
+      "integrity": "sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==",
       "license": "MIT",
       "dependencies": {
         "is-hex-prefixed": "1.0.0",
@@ -26589,6 +27289,8 @@
     },
     "node_modules/ganache-core/node_modules/eventemitter3": {
       "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
+      "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ==",
       "license": "MIT",
       "optional": true
     },
@@ -26601,6 +27303,8 @@
     },
     "node_modules/ganache-core/node_modules/evp_bytestokey": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
       "license": "MIT",
       "dependencies": {
         "md5.js": "^1.3.4",
@@ -26609,6 +27313,8 @@
     },
     "node_modules/ganache-core/node_modules/expand-brackets": {
       "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+      "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
       "license": "MIT",
       "dependencies": {
         "debug": "^2.3.3",
@@ -26625,6 +27331,8 @@
     },
     "node_modules/ganache-core/node_modules/expand-brackets/node_modules/debug": {
       "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -26632,6 +27340,8 @@
     },
     "node_modules/ganache-core/node_modules/expand-brackets/node_modules/define-property": {
       "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+      "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
       "license": "MIT",
       "dependencies": {
         "is-descriptor": "^0.1.0"
@@ -26642,6 +27352,8 @@
     },
     "node_modules/ganache-core/node_modules/expand-brackets/node_modules/extend-shallow": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
       "license": "MIT",
       "dependencies": {
         "is-extendable": "^0.1.0"
@@ -26652,6 +27364,8 @@
     },
     "node_modules/ganache-core/node_modules/expand-brackets/node_modules/is-accessor-descriptor": {
       "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "license": "MIT",
       "dependencies": {
         "kind-of": "^3.0.2"
@@ -26662,6 +27376,8 @@
     },
     "node_modules/ganache-core/node_modules/expand-brackets/node_modules/is-accessor-descriptor/node_modules/kind-of": {
       "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "license": "MIT",
       "dependencies": {
         "is-buffer": "^1.1.5"
@@ -26672,10 +27388,14 @@
     },
     "node_modules/ganache-core/node_modules/expand-brackets/node_modules/is-buffer": {
       "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/expand-brackets/node_modules/is-data-descriptor": {
       "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "license": "MIT",
       "dependencies": {
         "kind-of": "^3.0.2"
@@ -26686,6 +27406,8 @@
     },
     "node_modules/ganache-core/node_modules/expand-brackets/node_modules/is-data-descriptor/node_modules/kind-of": {
       "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "license": "MIT",
       "dependencies": {
         "is-buffer": "^1.1.5"
@@ -26696,6 +27418,8 @@
     },
     "node_modules/ganache-core/node_modules/expand-brackets/node_modules/is-descriptor": {
       "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
       "license": "MIT",
       "dependencies": {
         "is-accessor-descriptor": "^0.1.6",
@@ -26708,6 +27432,8 @@
     },
     "node_modules/ganache-core/node_modules/expand-brackets/node_modules/is-extendable": {
       "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -26715,6 +27441,8 @@
     },
     "node_modules/ganache-core/node_modules/expand-brackets/node_modules/kind-of": {
       "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+      "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -26722,10 +27450,14 @@
     },
     "node_modules/ganache-core/node_modules/expand-brackets/node_modules/ms": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/express": {
       "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
+      "integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -26766,6 +27498,8 @@
     },
     "node_modules/ganache-core/node_modules/express/node_modules/debug": {
       "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -26774,11 +27508,15 @@
     },
     "node_modules/ganache-core/node_modules/express/node_modules/ms": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/express/node_modules/qs": {
       "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+      "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
       "license": "BSD-3-Clause",
       "optional": true,
       "engines": {
@@ -26787,11 +27525,15 @@
     },
     "node_modules/ganache-core/node_modules/express/node_modules/safe-buffer": {
       "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/ext": {
       "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
+      "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
       "license": "ISC",
       "dependencies": {
         "type": "^2.0.0"
@@ -26803,10 +27545,14 @@
     },
     "node_modules/ganache-core/node_modules/extend": {
       "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/extend-shallow": {
       "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "license": "MIT",
       "dependencies": {
         "assign-symbols": "^1.0.0",
@@ -26818,6 +27564,8 @@
     },
     "node_modules/ganache-core/node_modules/extglob": {
       "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+      "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
       "license": "MIT",
       "dependencies": {
         "array-unique": "^0.3.2",
@@ -26835,6 +27583,8 @@
     },
     "node_modules/ganache-core/node_modules/extglob/node_modules/define-property": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+      "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
       "license": "MIT",
       "dependencies": {
         "is-descriptor": "^1.0.0"
@@ -26845,6 +27595,8 @@
     },
     "node_modules/ganache-core/node_modules/extglob/node_modules/extend-shallow": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
       "license": "MIT",
       "dependencies": {
         "is-extendable": "^0.1.0"
@@ -26855,6 +27607,8 @@
     },
     "node_modules/ganache-core/node_modules/extglob/node_modules/is-extendable": {
       "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -26862,6 +27616,8 @@
     },
     "node_modules/ganache-core/node_modules/extsprintf": {
       "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "engines": [
         "node >=0.6.0"
       ],
@@ -26869,6 +27625,8 @@
     },
     "node_modules/ganache-core/node_modules/fake-merkle-patricia-tree": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fake-merkle-patricia-tree/-/fake-merkle-patricia-tree-1.0.1.tgz",
+      "integrity": "sha1-S4w6z7Ugr635hgsfFM2M40As3dM=",
       "license": "ISC",
       "dependencies": {
         "checkpoint-store": "^1.1.0"
@@ -26876,14 +27634,20 @@
     },
     "node_modules/ganache-core/node_modules/fast-deep-equal": {
       "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/fetch-ponyfill": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/fetch-ponyfill/-/fetch-ponyfill-4.1.0.tgz",
+      "integrity": "sha1-rjzl9zLGReq4fkroeTQUcJsjmJM=",
       "license": "MIT",
       "dependencies": {
         "node-fetch": "~1.7.1"
@@ -26891,6 +27655,8 @@
     },
     "node_modules/ganache-core/node_modules/fetch-ponyfill/node_modules/is-stream": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -26898,6 +27664,8 @@
     },
     "node_modules/ganache-core/node_modules/fetch-ponyfill/node_modules/node-fetch": {
       "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
       "license": "MIT",
       "dependencies": {
         "encoding": "^0.1.11",
@@ -26906,6 +27674,8 @@
     },
     "node_modules/ganache-core/node_modules/finalhandler": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+      "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -26923,6 +27693,8 @@
     },
     "node_modules/ganache-core/node_modules/finalhandler/node_modules/debug": {
       "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -26931,11 +27703,15 @@
     },
     "node_modules/ganache-core/node_modules/finalhandler/node_modules/ms": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/find-yarn-workspace-root": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-1.2.1.tgz",
+      "integrity": "sha512-dVtfb0WuQG+8Ag2uWkbG79hOUzEsRrhBzgfn86g2sJPkzmcpGdghbNTfUKGTxymFrY/tLIodDzLoW9nOJ4FY8Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "fs-extra": "^4.0.3",
@@ -26944,6 +27720,8 @@
     },
     "node_modules/ganache-core/node_modules/find-yarn-workspace-root/node_modules/braces": {
       "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
       "license": "MIT",
       "dependencies": {
         "arr-flatten": "^1.1.0",
@@ -26963,6 +27741,8 @@
     },
     "node_modules/ganache-core/node_modules/find-yarn-workspace-root/node_modules/braces/node_modules/extend-shallow": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
       "license": "MIT",
       "dependencies": {
         "is-extendable": "^0.1.0"
@@ -26973,6 +27753,8 @@
     },
     "node_modules/ganache-core/node_modules/find-yarn-workspace-root/node_modules/fill-range": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+      "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
       "license": "MIT",
       "dependencies": {
         "extend-shallow": "^2.0.1",
@@ -26986,6 +27768,8 @@
     },
     "node_modules/ganache-core/node_modules/find-yarn-workspace-root/node_modules/fill-range/node_modules/extend-shallow": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
       "license": "MIT",
       "dependencies": {
         "is-extendable": "^0.1.0"
@@ -26996,6 +27780,8 @@
     },
     "node_modules/ganache-core/node_modules/find-yarn-workspace-root/node_modules/fs-extra": {
       "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+      "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.1.2",
@@ -27005,10 +27791,14 @@
     },
     "node_modules/ganache-core/node_modules/find-yarn-workspace-root/node_modules/is-buffer": {
       "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/find-yarn-workspace-root/node_modules/is-extendable": {
       "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -27016,6 +27806,8 @@
     },
     "node_modules/ganache-core/node_modules/find-yarn-workspace-root/node_modules/is-number": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
       "license": "MIT",
       "dependencies": {
         "kind-of": "^3.0.2"
@@ -27026,6 +27818,8 @@
     },
     "node_modules/ganache-core/node_modules/find-yarn-workspace-root/node_modules/is-number/node_modules/kind-of": {
       "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "license": "MIT",
       "dependencies": {
         "is-buffer": "^1.1.5"
@@ -27036,6 +27830,8 @@
     },
     "node_modules/ganache-core/node_modules/find-yarn-workspace-root/node_modules/micromatch": {
       "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
       "license": "MIT",
       "dependencies": {
         "arr-diff": "^4.0.0",
@@ -27058,6 +27854,8 @@
     },
     "node_modules/ganache-core/node_modules/find-yarn-workspace-root/node_modules/to-regex-range": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "license": "MIT",
       "dependencies": {
         "is-number": "^3.0.0",
@@ -27069,10 +27867,14 @@
     },
     "node_modules/ganache-core/node_modules/flow-stoplight": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/flow-stoplight/-/flow-stoplight-1.0.0.tgz",
+      "integrity": "sha1-SiksW8/4s5+mzAyxqFPYbyfu/3s=",
       "license": "ISC"
     },
     "node_modules/ganache-core/node_modules/for-each": {
       "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
       "license": "MIT",
       "dependencies": {
         "is-callable": "^1.1.3"
@@ -27080,6 +27882,8 @@
     },
     "node_modules/ganache-core/node_modules/for-in": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -27087,6 +27891,8 @@
     },
     "node_modules/ganache-core/node_modules/forever-agent": {
       "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
       "license": "Apache-2.0",
       "engines": {
         "node": "*"
@@ -27094,6 +27900,8 @@
     },
     "node_modules/ganache-core/node_modules/form-data": {
       "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -27114,6 +27922,8 @@
     },
     "node_modules/ganache-core/node_modules/fragment-cache": {
       "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "license": "MIT",
       "dependencies": {
         "map-cache": "^0.2.2"
@@ -27124,6 +27934,8 @@
     },
     "node_modules/ganache-core/node_modules/fresh": {
       "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -27132,6 +27944,8 @@
     },
     "node_modules/ganache-core/node_modules/fs-extra": {
       "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.1.2",
@@ -27144,14 +27958,20 @@
     },
     "node_modules/ganache-core/node_modules/fs.realpath": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "license": "ISC"
     },
     "node_modules/ganache-core/node_modules/function-bind": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/functional-red-black-tree": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/get-intrinsic": {
@@ -27168,6 +27988,8 @@
     },
     "node_modules/ganache-core/node_modules/get-stream": {
       "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -27182,6 +28004,8 @@
     },
     "node_modules/ganache-core/node_modules/get-value": {
       "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -27189,6 +28013,8 @@
     },
     "node_modules/ganache-core/node_modules/getpass": {
       "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "license": "MIT",
       "dependencies": {
         "assert-plus": "^1.0.0"
@@ -27211,6 +28037,8 @@
     },
     "node_modules/ganache-core/node_modules/global": {
       "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
+      "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
       "license": "MIT",
       "dependencies": {
         "min-document": "^2.19.0",
@@ -27219,6 +28047,8 @@
     },
     "node_modules/ganache-core/node_modules/got": {
       "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
+      "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -27240,6 +28070,8 @@
     },
     "node_modules/ganache-core/node_modules/got/node_modules/get-stream": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -27255,6 +28087,8 @@
     },
     "node_modules/ganache-core/node_modules/har-schema": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
       "license": "ISC",
       "engines": {
         "node": ">=4"
@@ -27262,6 +28096,8 @@
     },
     "node_modules/ganache-core/node_modules/har-validator": {
       "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.3",
@@ -27273,6 +28109,8 @@
     },
     "node_modules/ganache-core/node_modules/has": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.1"
@@ -27283,6 +28121,8 @@
     },
     "node_modules/ganache-core/node_modules/has-ansi": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^2.0.0"
@@ -27293,6 +28133,8 @@
     },
     "node_modules/ganache-core/node_modules/has-ansi/node_modules/ansi-regex": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -27300,6 +28142,8 @@
     },
     "node_modules/ganache-core/node_modules/has-flag": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -27307,6 +28151,8 @@
     },
     "node_modules/ganache-core/node_modules/has-symbol-support-x": {
       "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
+      "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -27325,6 +28171,8 @@
     },
     "node_modules/ganache-core/node_modules/has-to-string-tag-x": {
       "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
+      "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -27336,6 +28184,8 @@
     },
     "node_modules/ganache-core/node_modules/has-value": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "license": "MIT",
       "dependencies": {
         "get-value": "^2.0.6",
@@ -27348,6 +28198,8 @@
     },
     "node_modules/ganache-core/node_modules/has-values": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "license": "MIT",
       "dependencies": {
         "is-number": "^3.0.0",
@@ -27359,10 +28211,14 @@
     },
     "node_modules/ganache-core/node_modules/has-values/node_modules/is-buffer": {
       "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/has-values/node_modules/is-number": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
       "license": "MIT",
       "dependencies": {
         "kind-of": "^3.0.2"
@@ -27373,6 +28229,8 @@
     },
     "node_modules/ganache-core/node_modules/has-values/node_modules/is-number/node_modules/kind-of": {
       "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "license": "MIT",
       "dependencies": {
         "is-buffer": "^1.1.5"
@@ -27383,6 +28241,8 @@
     },
     "node_modules/ganache-core/node_modules/has-values/node_modules/kind-of": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+      "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
       "license": "MIT",
       "dependencies": {
         "is-buffer": "^1.1.5"
@@ -27393,6 +28253,8 @@
     },
     "node_modules/ganache-core/node_modules/hash-base": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
+      "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.4",
@@ -27405,6 +28267,8 @@
     },
     "node_modules/ganache-core/node_modules/hash-base/node_modules/readable-stream": {
       "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -27417,6 +28281,8 @@
     },
     "node_modules/ganache-core/node_modules/hash.js": {
       "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -27424,10 +28290,14 @@
       }
     },
     "node_modules/ganache-core/node_modules/heap": {
-      "version": "0.2.6"
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/heap/-/heap-0.2.6.tgz",
+      "integrity": "sha1-CH4fELBGky/IWU3Z5tN4r8nR5aw="
     },
     "node_modules/ganache-core/node_modules/hmac-drbg": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "license": "MIT",
       "dependencies": {
         "hash.js": "^1.0.3",
@@ -27437,6 +28307,8 @@
     },
     "node_modules/ganache-core/node_modules/home-or-tmp": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+      "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
       "license": "MIT",
       "dependencies": {
         "os-homedir": "^1.0.0",
@@ -27448,11 +28320,15 @@
     },
     "node_modules/ganache-core/node_modules/http-cache-semantics": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
+      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
       "license": "BSD-2-Clause",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/http-errors": {
       "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+      "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -27468,16 +28344,22 @@
     },
     "node_modules/ganache-core/node_modules/http-errors/node_modules/inherits": {
       "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "license": "ISC",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/http-https": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/http-https/-/http-https-1.0.0.tgz",
+      "integrity": "sha1-L5CN1fHbQGjAWM1ubUzjkskTOJs=",
       "license": "ISC",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/http-signature": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "license": "MIT",
       "dependencies": {
         "assert-plus": "^1.0.0",
@@ -27491,6 +28373,8 @@
     },
     "node_modules/ganache-core/node_modules/iconv-lite": {
       "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -27502,6 +28386,8 @@
     },
     "node_modules/ganache-core/node_modules/idna-uts46-hx": {
       "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/idna-uts46-hx/-/idna-uts46-hx-2.3.1.tgz",
+      "integrity": "sha512-PWoF9Keq6laYdIRwwCdhTPl60xRqAloYNMQLiyUnG42VjT53oW07BXIRM+NK7eQjzXjAk2gUvX9caRxlnF9TAA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -27513,6 +28399,8 @@
     },
     "node_modules/ganache-core/node_modules/idna-uts46-hx/node_modules/punycode": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+      "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -27521,6 +28409,8 @@
     },
     "node_modules/ganache-core/node_modules/ieee754": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
       "funding": [
         {
           "type": "github",
@@ -27539,10 +28429,14 @@
     },
     "node_modules/ganache-core/node_modules/immediate": {
       "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
+      "integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/inflight": {
       "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
@@ -27551,10 +28445,14 @@
     },
     "node_modules/ganache-core/node_modules/inherits": {
       "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
     "node_modules/ganache-core/node_modules/invariant": {
       "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.0.0"
@@ -27562,6 +28460,8 @@
     },
     "node_modules/ganache-core/node_modules/ipaddr.js": {
       "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -27570,6 +28470,8 @@
     },
     "node_modules/ganache-core/node_modules/is-accessor-descriptor": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+      "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
       "license": "MIT",
       "dependencies": {
         "kind-of": "^6.0.0"
@@ -27603,6 +28505,8 @@
     },
     "node_modules/ganache-core/node_modules/is-ci": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+      "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
       "license": "MIT",
       "dependencies": {
         "ci-info": "^2.0.0"
@@ -27613,6 +28517,8 @@
     },
     "node_modules/ganache-core/node_modules/is-data-descriptor": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+      "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
       "license": "MIT",
       "dependencies": {
         "kind-of": "^6.0.0"
@@ -27633,6 +28539,8 @@
     },
     "node_modules/ganache-core/node_modules/is-descriptor": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+      "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
       "license": "MIT",
       "dependencies": {
         "is-accessor-descriptor": "^1.0.0",
@@ -27645,6 +28553,8 @@
     },
     "node_modules/ganache-core/node_modules/is-extendable": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+      "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
       "license": "MIT",
       "dependencies": {
         "is-plain-object": "^2.0.4"
@@ -27655,6 +28565,8 @@
     },
     "node_modules/ganache-core/node_modules/is-finite": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
+      "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -27665,6 +28577,8 @@
     },
     "node_modules/ganache-core/node_modules/is-fn": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fn/-/is-fn-1.0.0.tgz",
+      "integrity": "sha1-lUPV3nvPWwiiLsiiC65uKG1RDYw=",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -27672,10 +28586,14 @@
     },
     "node_modules/ganache-core/node_modules/is-function": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz",
+      "integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ==",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/is-hex-prefixed": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
+      "integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ=",
       "license": "MIT",
       "engines": {
         "node": ">=6.5.0",
@@ -27694,6 +28612,8 @@
     },
     "node_modules/ganache-core/node_modules/is-object": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.2.tgz",
+      "integrity": "sha512-2rRIahhZr2UWb45fIOuvZGpFtz0TyOZLf32KxBbSoUCeZR495zCKlWUKKUByk3geS2eAs7ZAABt0Y/Rx0GiQGA==",
       "license": "MIT",
       "optional": true,
       "funding": {
@@ -27702,6 +28622,8 @@
     },
     "node_modules/ganache-core/node_modules/is-plain-obj": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -27710,6 +28632,8 @@
     },
     "node_modules/ganache-core/node_modules/is-plain-object": {
       "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "license": "MIT",
       "dependencies": {
         "isobject": "^3.0.1"
@@ -27733,6 +28657,8 @@
     },
     "node_modules/ganache-core/node_modules/is-retry-allowed": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
+      "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -27754,10 +28680,14 @@
     },
     "node_modules/ganache-core/node_modules/is-typedarray": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/is-windows": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -27765,14 +28695,20 @@
     },
     "node_modules/ganache-core/node_modules/isarray": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/isexe": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "license": "ISC"
     },
     "node_modules/ganache-core/node_modules/isobject": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -27780,10 +28716,14 @@
     },
     "node_modules/ganache-core/node_modules/isstream": {
       "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/isurl": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
+      "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -27796,6 +28736,8 @@
     },
     "node_modules/ganache-core/node_modules/js-sha3": {
       "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
+      "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=",
       "license": "MIT",
       "optional": true
     },
@@ -27805,15 +28747,21 @@
     },
     "node_modules/ganache-core/node_modules/jsbn": {
       "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/json-buffer": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
+      "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
       "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/json-rpc-engine": {
       "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/json-rpc-engine/-/json-rpc-engine-3.8.0.tgz",
+      "integrity": "sha512-6QNcvm2gFuuK4TKU1uwfH0Qd/cOSb9c1lls0gbnIhciktIUQJwz6NQNAW4B1KiGPenv7IKu97V222Yo1bNhGuA==",
       "license": "ISC",
       "dependencies": {
         "async": "^2.0.1",
@@ -27826,6 +28774,8 @@
     },
     "node_modules/ganache-core/node_modules/json-rpc-error": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/json-rpc-error/-/json-rpc-error-2.0.0.tgz",
+      "integrity": "sha1-p6+cICg4tekFxyUOVH8a/3cligI=",
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.1"
@@ -27833,17 +28783,25 @@
     },
     "node_modules/ganache-core/node_modules/json-rpc-random-id": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-rpc-random-id/-/json-rpc-random-id-1.0.1.tgz",
+      "integrity": "sha1-uknZat7RRE27jaPSA3SKy7zeyMg=",
       "license": "ISC"
     },
     "node_modules/ganache-core/node_modules/json-schema": {
-      "version": "0.2.3"
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
     "node_modules/ganache-core/node_modules/json-schema-traverse": {
       "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/json-stable-stringify": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "license": "MIT",
       "dependencies": {
         "jsonify": "~0.0.0"
@@ -27851,10 +28809,14 @@
     },
     "node_modules/ganache-core/node_modules/json-stringify-safe": {
       "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "license": "ISC"
     },
     "node_modules/ganache-core/node_modules/jsonfile": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "license": "MIT",
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
@@ -27862,10 +28824,14 @@
     },
     "node_modules/ganache-core/node_modules/jsonify": {
       "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
       "license": "Public Domain"
     },
     "node_modules/ganache-core/node_modules/jsprim": {
       "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
       "engines": [
         "node >=0.6.0"
       ],
@@ -27879,6 +28845,8 @@
     },
     "node_modules/ganache-core/node_modules/keccak": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.1.tgz",
+      "integrity": "sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==",
       "hasInstallScript": true,
       "inBundle": true,
       "license": "MIT",
@@ -27892,6 +28860,8 @@
     },
     "node_modules/ganache-core/node_modules/keyv": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
+      "integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -27900,6 +28870,8 @@
     },
     "node_modules/ganache-core/node_modules/kind-of": {
       "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -27907,6 +28879,8 @@
     },
     "node_modules/ganache-core/node_modules/klaw-sync": {
       "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.1.11"
@@ -27914,6 +28888,8 @@
     },
     "node_modules/ganache-core/node_modules/level-codec": {
       "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.2.tgz",
+      "integrity": "sha512-UyIwNb1lJBChJnGfjmO0OR+ezh2iVu1Kas3nvBS/BzGnx79dv6g7unpKIDNPMhfdTEGoc7mC8uAu51XEtX+FHQ==",
       "license": "MIT",
       "dependencies": {
         "buffer": "^5.6.0"
@@ -27924,6 +28900,8 @@
     },
     "node_modules/ganache-core/node_modules/level-errors": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-2.0.1.tgz",
+      "integrity": "sha512-UVprBJXite4gPS+3VznfgDSU8PTRuVX0NXwoWW50KLxd2yw4Y1t2JUR5In1itQnudZqRMT9DlAM3Q//9NCjCFw==",
       "license": "MIT",
       "dependencies": {
         "errno": "~0.1.1"
@@ -27934,6 +28912,8 @@
     },
     "node_modules/ganache-core/node_modules/level-iterator-stream": {
       "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-2.0.3.tgz",
+      "integrity": "sha512-I6Heg70nfF+e5Y3/qfthJFexhRw/Gi3bIymCoXAlijZdAcLaPuWSJs3KXyTYf23ID6g0o2QF62Yh+grOXY3Rig==",
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.1",
@@ -27946,6 +28926,8 @@
     },
     "node_modules/ganache-core/node_modules/level-mem": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/level-mem/-/level-mem-3.0.1.tgz",
+      "integrity": "sha512-LbtfK9+3Ug1UmvvhR2DqLqXiPW1OJ5jEh0a3m9ZgAipiwpSxGj/qaVVy54RG5vAQN1nCuXqjvprCuKSCxcJHBg==",
       "license": "MIT",
       "dependencies": {
         "level-packager": "~4.0.0",
@@ -27957,6 +28939,8 @@
     },
     "node_modules/ganache-core/node_modules/level-mem/node_modules/abstract-leveldown": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-5.0.0.tgz",
+      "integrity": "sha512-5mU5P1gXtsMIXg65/rsYGsi93+MlogXZ9FA8JnwKurHQg64bfXwGYVdVdijNTVNOlAsuIiOwHdvFFD5JqCJQ7A==",
       "license": "MIT",
       "dependencies": {
         "xtend": "~4.0.0"
@@ -27967,10 +28951,14 @@
     },
     "node_modules/ganache-core/node_modules/level-mem/node_modules/ltgt": {
       "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
+      "integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/level-mem/node_modules/memdown": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/memdown/-/memdown-3.0.0.tgz",
+      "integrity": "sha512-tbV02LfZMWLcHcq4tw++NuqMO+FZX8tNJEiD2aNRm48ZZusVg5N8NART+dmBkepJVye986oixErf7jfXboMGMA==",
       "license": "MIT",
       "dependencies": {
         "abstract-leveldown": "~5.0.0",
@@ -27986,10 +28974,14 @@
     },
     "node_modules/ganache-core/node_modules/level-mem/node_modules/safe-buffer": {
       "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/level-packager": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-4.0.1.tgz",
+      "integrity": "sha512-svCRKfYLn9/4CoFfi+d8krOtrp6RoX8+xm0Na5cgXMqSyRru0AnDYdLl+YI8u1FyS6gGZ94ILLZDE5dh2but3Q==",
       "license": "MIT",
       "dependencies": {
         "encoding-down": "~5.0.0",
@@ -28001,6 +28993,8 @@
     },
     "node_modules/ganache-core/node_modules/level-post": {
       "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/level-post/-/level-post-1.0.7.tgz",
+      "integrity": "sha512-PWYqG4Q00asOrLhX7BejSajByB4EmG2GaKHfj3h5UmmZ2duciXLPGYWIjBzLECFWUGOZWlm5B20h/n3Gs3HKew==",
       "license": "MIT",
       "dependencies": {
         "ltgt": "^2.1.2"
@@ -28008,6 +29002,8 @@
     },
     "node_modules/ganache-core/node_modules/level-sublevel": {
       "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/level-sublevel/-/level-sublevel-6.6.4.tgz",
+      "integrity": "sha512-pcCrTUOiO48+Kp6F1+UAzF/OtWqLcQVTVF39HLdZ3RO8XBoXt+XVPKZO1vVr1aUoxHZA9OtD2e1v7G+3S5KFDA==",
       "license": "MIT",
       "dependencies": {
         "bytewise": "~1.1.0",
@@ -28024,6 +29020,8 @@
     },
     "node_modules/ganache-core/node_modules/level-ws": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/level-ws/-/level-ws-1.0.0.tgz",
+      "integrity": "sha512-RXEfCmkd6WWFlArh3X8ONvQPm8jNpfA0s/36M4QzLqrLEIt1iJE9WBHLZ5vZJK6haMjJPJGJCQWfjMNnRcq/9Q==",
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -28036,6 +29034,8 @@
     },
     "node_modules/ganache-core/node_modules/levelup": {
       "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/levelup/-/levelup-3.1.1.tgz",
+      "integrity": "sha512-9N10xRkUU4dShSRRFTBdNaBxofz+PGaIZO962ckboJZiNmLuhVT6FZ6ZKAsICKfUBO76ySaYU6fJWX/jnj3Lcg==",
       "license": "MIT",
       "dependencies": {
         "deferred-leveldown": "~4.0.0",
@@ -28049,6 +29049,8 @@
     },
     "node_modules/ganache-core/node_modules/levelup/node_modules/level-iterator-stream": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-3.0.1.tgz",
+      "integrity": "sha512-nEIQvxEED9yRThxvOrq8Aqziy4EGzrxSZK+QzEFAVuJvQ8glfyZ96GB6BoI4sBbLfjMXm2w4vu3Tkcm9obcY0g==",
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.1",
@@ -28061,14 +29063,20 @@
     },
     "node_modules/ganache-core/node_modules/lodash": {
       "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/looper": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/looper/-/looper-2.0.0.tgz",
+      "integrity": "sha1-Zs0Md0rz1P7axTeU90LbVtqPCew=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/loose-envify": {
       "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -28079,6 +29087,8 @@
     },
     "node_modules/ganache-core/node_modules/lowercase-keys": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -28087,6 +29097,8 @@
     },
     "node_modules/ganache-core/node_modules/lru-cache": {
       "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
@@ -28094,10 +29106,14 @@
     },
     "node_modules/ganache-core/node_modules/ltgt": {
       "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.1.3.tgz",
+      "integrity": "sha1-EIUaBtmWS5cReEQcI8nlJpjuzjQ=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/map-cache": {
       "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -28105,6 +29121,8 @@
     },
     "node_modules/ganache-core/node_modules/map-visit": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "license": "MIT",
       "dependencies": {
         "object-visit": "^1.0.0"
@@ -28115,6 +29133,8 @@
     },
     "node_modules/ganache-core/node_modules/md5.js": {
       "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
       "license": "MIT",
       "dependencies": {
         "hash-base": "^3.0.0",
@@ -28124,6 +29144,8 @@
     },
     "node_modules/ganache-core/node_modules/media-typer": {
       "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -28132,11 +29154,15 @@
     },
     "node_modules/ganache-core/node_modules/merge-descriptors": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
       "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/merkle-patricia-tree": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-3.0.0.tgz",
+      "integrity": "sha512-soRaMuNf/ILmw3KWbybaCjhx86EYeBbD8ph0edQCTed0JN/rxDt1EBN52Ajre3VyGo+91f8+/rfPIRQnnGMqmQ==",
       "license": "MPL-2.0",
       "dependencies": {
         "async": "^2.6.1",
@@ -28150,6 +29176,8 @@
     },
     "node_modules/ganache-core/node_modules/merkle-patricia-tree/node_modules/ethereumjs-util": {
       "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+      "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
       "license": "MPL-2.0",
       "dependencies": {
         "bn.js": "^4.11.0",
@@ -28163,6 +29191,8 @@
     },
     "node_modules/ganache-core/node_modules/merkle-patricia-tree/node_modules/readable-stream": {
       "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -28175,6 +29205,8 @@
     },
     "node_modules/ganache-core/node_modules/methods": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -28183,6 +29215,8 @@
     },
     "node_modules/ganache-core/node_modules/miller-rabin": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
+      "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
       "license": "MIT",
       "dependencies": {
         "bn.js": "^4.0.0",
@@ -28194,6 +29228,8 @@
     },
     "node_modules/ganache-core/node_modules/mime": {
       "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
       "license": "MIT",
       "optional": true,
       "bin": {
@@ -28222,6 +29258,8 @@
     },
     "node_modules/ganache-core/node_modules/mimic-response": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -28230,20 +29268,28 @@
     },
     "node_modules/ganache-core/node_modules/min-document": {
       "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+      "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
       "dependencies": {
         "dom-walk": "^0.1.0"
       }
     },
     "node_modules/ganache-core/node_modules/minimalistic-assert": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
       "license": "ISC"
     },
     "node_modules/ganache-core/node_modules/minimalistic-crypto-utils": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/minimatch": {
       "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -28254,6 +29300,8 @@
     },
     "node_modules/ganache-core/node_modules/minimist": {
       "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/minizlib": {
@@ -28266,6 +29314,8 @@
     },
     "node_modules/ganache-core/node_modules/minizlib/node_modules/minipass": {
       "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+      "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -28275,6 +29325,8 @@
     },
     "node_modules/ganache-core/node_modules/mixin-deep": {
       "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
       "license": "MIT",
       "dependencies": {
         "for-in": "^1.0.2",
@@ -28286,6 +29338,8 @@
     },
     "node_modules/ganache-core/node_modules/mkdirp": {
       "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.5"
@@ -28296,6 +29350,8 @@
     },
     "node_modules/ganache-core/node_modules/mkdirp-promise": {
       "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mkdirp-promise/-/mkdirp-promise-5.0.1.tgz",
+      "integrity": "sha1-6bj2jlUsaKnBcTuEiD96HdA5uKE=",
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -28312,10 +29368,14 @@
     },
     "node_modules/ganache-core/node_modules/ms": {
       "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/multibase": {
       "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.6.1.tgz",
+      "integrity": "sha512-pFfAwyTjbbQgNc3G7D48JkJxWtoJoBMaR4xQUOuB8RnCgRqaYmWNFeJTTvrJ2w51bjLq2zTby6Rqj9TQ9elSUw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -28325,6 +29385,8 @@
     },
     "node_modules/ganache-core/node_modules/multicodec": {
       "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-0.5.7.tgz",
+      "integrity": "sha512-PscoRxm3f+88fAtELwUnZxGDkduE2HD9Q6GHUOywQLjOGT/HAdhjLDYNZ1e7VR0s0TP0EwZ16LNUTFpoBGivOA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -28333,6 +29395,8 @@
     },
     "node_modules/ganache-core/node_modules/multihashes": {
       "version": "0.4.21",
+      "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.21.tgz",
+      "integrity": "sha512-uVSvmeCWf36pU2nB4/1kzYZjsXD9vofZKpgudqkceYY5g2aZZXJ5r9lxuzoRLl1OAp28XljXsEJ/X/85ZsKmKw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -28343,6 +29407,8 @@
     },
     "node_modules/ganache-core/node_modules/multihashes/node_modules/multibase": {
       "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
+      "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -28352,11 +29418,15 @@
     },
     "node_modules/ganache-core/node_modules/nano-json-stream-parser": {
       "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/nano-json-stream-parser/-/nano-json-stream-parser-0.1.2.tgz",
+      "integrity": "sha1-DMj20OK2IrR5xA1JnEbWS3Vcb18=",
       "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/nanomatch": {
       "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+      "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
       "license": "MIT",
       "dependencies": {
         "arr-diff": "^4.0.0",
@@ -28377,6 +29447,8 @@
     },
     "node_modules/ganache-core/node_modules/negotiator": {
       "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
+      "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -28385,14 +29457,20 @@
     },
     "node_modules/ganache-core/node_modules/next-tick": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/nice-try": {
       "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/node-addon-api": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
+      "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==",
       "inBundle": true,
       "license": "MIT"
     },
@@ -28405,6 +29483,8 @@
     },
     "node_modules/ganache-core/node_modules/node-gyp-build": {
       "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
+      "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==",
       "inBundle": true,
       "license": "MIT",
       "bin": {
@@ -28423,6 +29503,8 @@
     },
     "node_modules/ganache-core/node_modules/number-to-bn": {
       "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
+      "integrity": "sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -28436,11 +29518,15 @@
     },
     "node_modules/ganache-core/node_modules/number-to-bn/node_modules/bn.js": {
       "version": "4.11.6",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+      "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
       "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/oauth-sign": {
       "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": "*"
@@ -28448,6 +29534,8 @@
     },
     "node_modules/ganache-core/node_modules/object-assign": {
       "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -28455,6 +29543,8 @@
     },
     "node_modules/ganache-core/node_modules/object-copy": {
       "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "license": "MIT",
       "dependencies": {
         "copy-descriptor": "^0.1.0",
@@ -28467,6 +29557,8 @@
     },
     "node_modules/ganache-core/node_modules/object-copy/node_modules/define-property": {
       "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+      "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
       "license": "MIT",
       "dependencies": {
         "is-descriptor": "^0.1.0"
@@ -28477,6 +29569,8 @@
     },
     "node_modules/ganache-core/node_modules/object-copy/node_modules/is-accessor-descriptor": {
       "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "license": "MIT",
       "dependencies": {
         "kind-of": "^3.0.2"
@@ -28487,10 +29581,14 @@
     },
     "node_modules/ganache-core/node_modules/object-copy/node_modules/is-buffer": {
       "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/object-copy/node_modules/is-data-descriptor": {
       "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "license": "MIT",
       "dependencies": {
         "kind-of": "^3.0.2"
@@ -28501,6 +29599,8 @@
     },
     "node_modules/ganache-core/node_modules/object-copy/node_modules/is-descriptor": {
       "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
       "license": "MIT",
       "dependencies": {
         "is-accessor-descriptor": "^0.1.6",
@@ -28513,6 +29613,8 @@
     },
     "node_modules/ganache-core/node_modules/object-copy/node_modules/is-descriptor/node_modules/kind-of": {
       "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+      "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -28520,6 +29622,8 @@
     },
     "node_modules/ganache-core/node_modules/object-copy/node_modules/kind-of": {
       "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "license": "MIT",
       "dependencies": {
         "is-buffer": "^1.1.5"
@@ -28551,6 +29655,8 @@
     },
     "node_modules/ganache-core/node_modules/object-keys": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -28558,6 +29664,8 @@
     },
     "node_modules/ganache-core/node_modules/object-visit": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "license": "MIT",
       "dependencies": {
         "isobject": "^3.0.0"
@@ -28599,6 +29707,8 @@
     },
     "node_modules/ganache-core/node_modules/object.pick": {
       "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "license": "MIT",
       "dependencies": {
         "isobject": "^3.0.1"
@@ -28609,6 +29719,8 @@
     },
     "node_modules/ganache-core/node_modules/oboe": {
       "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/oboe/-/oboe-2.1.4.tgz",
+      "integrity": "sha1-IMiM2wwVNxuwQRklfU/dNLCqSfY=",
       "license": "BSD",
       "optional": true,
       "dependencies": {
@@ -28617,6 +29729,8 @@
     },
     "node_modules/ganache-core/node_modules/on-finished": {
       "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -28628,6 +29742,8 @@
     },
     "node_modules/ganache-core/node_modules/once": {
       "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -28635,6 +29751,8 @@
     },
     "node_modules/ganache-core/node_modules/os-homedir": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -28642,6 +29760,8 @@
     },
     "node_modules/ganache-core/node_modules/os-tmpdir": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -28649,6 +29769,8 @@
     },
     "node_modules/ganache-core/node_modules/p-cancelable": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
+      "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -28657,6 +29779,8 @@
     },
     "node_modules/ganache-core/node_modules/p-timeout": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
+      "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -28668,6 +29792,8 @@
     },
     "node_modules/ganache-core/node_modules/p-timeout/node_modules/p-finally": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -28676,6 +29802,8 @@
     },
     "node_modules/ganache-core/node_modules/parse-asn1": {
       "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.6.tgz",
+      "integrity": "sha512-RnZRo1EPU6JBnra2vGHj0yhp6ebyjBZpmUCLHWiFhxlzvBCCpAuZ7elsBp1PVAbQN0/04VD/19rfzlBSwLstMw==",
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -28692,6 +29820,8 @@
     },
     "node_modules/ganache-core/node_modules/parseurl": {
       "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -28700,6 +29830,8 @@
     },
     "node_modules/ganache-core/node_modules/pascalcase": {
       "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -28707,6 +29839,8 @@
     },
     "node_modules/ganache-core/node_modules/patch-package": {
       "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-6.2.2.tgz",
+      "integrity": "sha512-YqScVYkVcClUY0v8fF0kWOjDYopzIM8e3bj/RU1DPeEF14+dCGm6UeOYm4jvCyxqIEQ5/eJzmbWfDWnUleFNMg==",
       "license": "MIT",
       "dependencies": {
         "@yarnpkg/lockfile": "^1.1.0",
@@ -28731,6 +29865,8 @@
     },
     "node_modules/ganache-core/node_modules/patch-package/node_modules/cross-spawn": {
       "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
       "license": "MIT",
       "dependencies": {
         "nice-try": "^1.0.4",
@@ -28745,6 +29881,8 @@
     },
     "node_modules/ganache-core/node_modules/patch-package/node_modules/path-key": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -28752,6 +29890,8 @@
     },
     "node_modules/ganache-core/node_modules/patch-package/node_modules/semver": {
       "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver"
@@ -28759,6 +29899,8 @@
     },
     "node_modules/ganache-core/node_modules/patch-package/node_modules/shebang-command": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^1.0.0"
@@ -28769,6 +29911,8 @@
     },
     "node_modules/ganache-core/node_modules/patch-package/node_modules/shebang-regex": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -28776,6 +29920,8 @@
     },
     "node_modules/ganache-core/node_modules/patch-package/node_modules/slash": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -28783,6 +29929,8 @@
     },
     "node_modules/ganache-core/node_modules/patch-package/node_modules/tmp": {
       "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "license": "MIT",
       "dependencies": {
         "os-tmpdir": "~1.0.2"
@@ -28793,6 +29941,8 @@
     },
     "node_modules/ganache-core/node_modules/patch-package/node_modules/which": {
       "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -28803,6 +29953,8 @@
     },
     "node_modules/ganache-core/node_modules/path-is-absolute": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -28814,6 +29966,8 @@
     },
     "node_modules/ganache-core/node_modules/path-to-regexp": {
       "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
       "license": "MIT",
       "optional": true
     },
@@ -28833,10 +29987,14 @@
     },
     "node_modules/ganache-core/node_modules/performance-now": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/posix-character-classes": {
       "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -28844,12 +30002,16 @@
     },
     "node_modules/ganache-core/node_modules/precond": {
       "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
+      "integrity": "sha1-qpWRvKokkj8eD0hJ0kD0fvwQdaw=",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/ganache-core/node_modules/prepend-http": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+      "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -28858,6 +30020,8 @@
     },
     "node_modules/ganache-core/node_modules/private": {
       "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -28865,6 +30029,8 @@
     },
     "node_modules/ganache-core/node_modules/process": {
       "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6.0"
@@ -28872,10 +30038,14 @@
     },
     "node_modules/ganache-core/node_modules/process-nextick-args": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/promise-to-callback": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/promise-to-callback/-/promise-to-callback-1.0.0.tgz",
+      "integrity": "sha1-XSp0kBC/tn2WNZj805YHRqaP7vc=",
       "license": "MIT",
       "dependencies": {
         "is-fn": "^1.0.0",
@@ -28899,18 +30069,26 @@
     },
     "node_modules/ganache-core/node_modules/prr": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/pseudomap": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "license": "ISC"
     },
     "node_modules/ganache-core/node_modules/psl": {
       "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/public-encrypt": {
       "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
+      "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -28924,14 +30102,20 @@
     },
     "node_modules/ganache-core/node_modules/pull-cat": {
       "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/pull-cat/-/pull-cat-1.1.11.tgz",
+      "integrity": "sha1-tkLdElXaN2pwa220+pYvX9t0wxs=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/pull-defer": {
       "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/pull-defer/-/pull-defer-0.2.3.tgz",
+      "integrity": "sha512-/An3KE7mVjZCqNhZsr22k1Tx8MACnUnHZZNPSJ0S62td8JtYr/AiRG42Vz7Syu31SoTLUzVIe61jtT/pNdjVYA==",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/pull-level": {
       "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pull-level/-/pull-level-2.0.4.tgz",
+      "integrity": "sha512-fW6pljDeUThpq5KXwKbRG3X7Ogk3vc75d5OQU/TvXXui65ykm+Bn+fiktg+MOx2jJ85cd+sheufPL+rw9QSVZg==",
       "license": "MIT",
       "dependencies": {
         "level-post": "^1.0.7",
@@ -28945,6 +30129,8 @@
     },
     "node_modules/ganache-core/node_modules/pull-live": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pull-live/-/pull-live-1.0.1.tgz",
+      "integrity": "sha1-pOzuAeMwFV6RJLu89HYfIbOPUfU=",
       "license": "MIT",
       "dependencies": {
         "pull-cat": "^1.1.9",
@@ -28953,14 +30139,20 @@
     },
     "node_modules/ganache-core/node_modules/pull-pushable": {
       "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pull-pushable/-/pull-pushable-2.2.0.tgz",
+      "integrity": "sha1-Xy867UethpGfAbEqLpnW8b13ZYE=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/pull-stream": {
       "version": "3.6.14",
+      "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.14.tgz",
+      "integrity": "sha512-KIqdvpqHHaTUA2mCYcLG1ibEbu/LCKoJZsBWyv9lSYtPkJPBq8m3Hxa103xHi6D2thj5YXa0TqK3L3GUkwgnew==",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/pull-window": {
       "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/pull-window/-/pull-window-2.1.4.tgz",
+      "integrity": "sha1-/DuG/uvRkgx64pdpHiP3BfiFUvA=",
       "license": "MIT",
       "dependencies": {
         "looper": "^2.0.0"
@@ -28968,6 +30160,8 @@
     },
     "node_modules/ganache-core/node_modules/pump": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -28977,6 +30171,8 @@
     },
     "node_modules/ganache-core/node_modules/punycode": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -28984,6 +30180,8 @@
     },
     "node_modules/ganache-core/node_modules/qs": {
       "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.6"
@@ -28991,6 +30189,8 @@
     },
     "node_modules/ganache-core/node_modules/query-string": {
       "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+      "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -29004,6 +30204,8 @@
     },
     "node_modules/ganache-core/node_modules/randombytes": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "^5.1.0"
@@ -29011,6 +30213,8 @@
     },
     "node_modules/ganache-core/node_modules/randomfill": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
+      "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -29020,6 +30224,8 @@
     },
     "node_modules/ganache-core/node_modules/range-parser": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -29028,6 +30234,8 @@
     },
     "node_modules/ganache-core/node_modules/raw-body": {
       "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
+      "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -29042,6 +30250,8 @@
     },
     "node_modules/ganache-core/node_modules/readable-stream": {
       "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -29055,18 +30265,26 @@
     },
     "node_modules/ganache-core/node_modules/readable-stream/node_modules/safe-buffer": {
       "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/regenerate": {
       "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
+      "integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/regenerator-runtime": {
       "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/regenerator-transform": {
       "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
+      "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
       "license": "BSD",
       "dependencies": {
         "babel-runtime": "^6.18.0",
@@ -29076,6 +30294,8 @@
     },
     "node_modules/ganache-core/node_modules/regex-not": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
       "license": "MIT",
       "dependencies": {
         "extend-shallow": "^3.0.2",
@@ -29124,6 +30344,8 @@
     },
     "node_modules/ganache-core/node_modules/regexpu-core": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
+      "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
       "license": "MIT",
       "dependencies": {
         "regenerate": "^1.2.1",
@@ -29133,10 +30355,14 @@
     },
     "node_modules/ganache-core/node_modules/regjsgen": {
       "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+      "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/regjsparser": {
       "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+      "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
       "license": "BSD",
       "dependencies": {
         "jsesc": "~0.5.0"
@@ -29147,6 +30373,8 @@
     },
     "node_modules/ganache-core/node_modules/regjsparser/node_modules/jsesc": {
       "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+      "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
       "bin": {
         "jsesc": "bin/jsesc"
       }
@@ -29160,6 +30388,8 @@
     },
     "node_modules/ganache-core/node_modules/repeat-string": {
       "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
       "license": "MIT",
       "engines": {
         "node": ">=0.10"
@@ -29167,6 +30397,8 @@
     },
     "node_modules/ganache-core/node_modules/repeating": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "license": "MIT",
       "dependencies": {
         "is-finite": "^1.0.0"
@@ -29177,6 +30409,8 @@
     },
     "node_modules/ganache-core/node_modules/request": {
       "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
       "license": "Apache-2.0",
       "dependencies": {
         "aws-sign2": "~0.7.0",
@@ -29206,10 +30440,14 @@
     },
     "node_modules/ganache-core/node_modules/resolve-url": {
       "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/responselike": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
+      "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -29218,6 +30456,8 @@
     },
     "node_modules/ganache-core/node_modules/resumer": {
       "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
+      "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
       "license": "MIT",
       "dependencies": {
         "through": "~2.3.4"
@@ -29225,6 +30465,8 @@
     },
     "node_modules/ganache-core/node_modules/ret": {
       "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
       "license": "MIT",
       "engines": {
         "node": ">=0.12"
@@ -29242,6 +30484,8 @@
     },
     "node_modules/ganache-core/node_modules/ripemd160": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+      "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
       "license": "MIT",
       "dependencies": {
         "hash-base": "^3.0.0",
@@ -29250,6 +30494,8 @@
     },
     "node_modules/ganache-core/node_modules/rlp": {
       "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.6.tgz",
+      "integrity": "sha512-HAfAmL6SDYNWPUOJNrM500x4Thn4PZsEy5pijPh40U9WfNk0z15hUYzO9xVIMAdIHdFtD8CBDHd75Td1g36Mjg==",
       "license": "MPL-2.0",
       "dependencies": {
         "bn.js": "^4.11.1"
@@ -29260,10 +30506,14 @@
     },
     "node_modules/ganache-core/node_modules/rustbn.js": {
       "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/rustbn.js/-/rustbn.js-0.2.0.tgz",
+      "integrity": "sha512-4VlvkRUuCJvr2J6Y0ImW7NvTCriMi7ErOAqWk1y69vAdoNIzCF3yPmgeNzx+RQTLEDFq5sHfscn1MwHxP9hNfA==",
       "license": "(MIT OR Apache-2.0)"
     },
     "node_modules/ganache-core/node_modules/safe-buffer": {
       "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
       "funding": [
         {
           "type": "github",
@@ -29282,6 +30532,8 @@
     },
     "node_modules/ganache-core/node_modules/safe-event-emitter": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/safe-event-emitter/-/safe-event-emitter-1.0.1.tgz",
+      "integrity": "sha512-e1wFe99A91XYYxoQbcq2ZJUWurxEyP8vfz7A7vuUe1s95q8r5ebraVaA1BukYJcpM6V16ugWoD9vngi8Ccu5fg==",
       "license": "ISC",
       "dependencies": {
         "events": "^3.0.0"
@@ -29289,6 +30541,8 @@
     },
     "node_modules/ganache-core/node_modules/safe-regex": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "license": "MIT",
       "dependencies": {
         "ret": "~0.1.10"
@@ -29296,14 +30550,20 @@
     },
     "node_modules/ganache-core/node_modules/safer-buffer": {
       "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/scrypt-js": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
+      "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/scryptsy": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/scryptsy/-/scryptsy-1.2.1.tgz",
+      "integrity": "sha1-oyJfpLJST4AnAHYeKFW987LZIWM=",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -29312,6 +30572,8 @@
     },
     "node_modules/ganache-core/node_modules/secp256k1": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
+      "integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -29325,16 +30587,22 @@
     },
     "node_modules/ganache-core/node_modules/seedrandom": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.1.tgz",
+      "integrity": "sha512-1/02Y/rUeU1CJBAGLebiC5Lbo5FnB22gQbIFFYTLkwvp1xdABZJH1sn4ZT1MzXmPpzv+Rf/Lu2NcsLJiK4rcDg==",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/semaphore": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/semaphore/-/semaphore-1.1.0.tgz",
+      "integrity": "sha512-O4OZEaNtkMd/K0i6js9SL+gqy0ZCBMgUvlSqHKi4IBdjhe7wB8pwztUk1BbZ1fmrvpwFrPbHzqd2w5pTcJH6LA==",
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/ganache-core/node_modules/send": {
       "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
+      "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -29358,6 +30626,8 @@
     },
     "node_modules/ganache-core/node_modules/send/node_modules/debug": {
       "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -29366,16 +30636,22 @@
     },
     "node_modules/ganache-core/node_modules/send/node_modules/debug/node_modules/ms": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/send/node_modules/ms": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
       "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/serve-static": {
       "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
+      "integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -29390,6 +30666,8 @@
     },
     "node_modules/ganache-core/node_modules/servify": {
       "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/servify/-/servify-0.1.12.tgz",
+      "integrity": "sha512-/xE6GvsKKqyo1BAY+KxOWXcLpPsUUyji7Qg3bVD7hh1eRze5bR1uYiuDA/k3Gof1s9BTzQZEJK8sNcNGFIzeWw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -29405,6 +30683,8 @@
     },
     "node_modules/ganache-core/node_modules/set-immediate-shim": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -29412,6 +30692,8 @@
     },
     "node_modules/ganache-core/node_modules/set-value": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
       "license": "MIT",
       "dependencies": {
         "extend-shallow": "^2.0.1",
@@ -29425,6 +30707,8 @@
     },
     "node_modules/ganache-core/node_modules/set-value/node_modules/extend-shallow": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
       "license": "MIT",
       "dependencies": {
         "is-extendable": "^0.1.0"
@@ -29435,6 +30719,8 @@
     },
     "node_modules/ganache-core/node_modules/set-value/node_modules/is-extendable": {
       "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -29442,15 +30728,21 @@
     },
     "node_modules/ganache-core/node_modules/setimmediate": {
       "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/setprototypeof": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
       "license": "ISC",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/sha.js": {
       "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "license": "(MIT AND BSD-3-Clause)",
       "dependencies": {
         "inherits": "^2.0.1",
@@ -29462,6 +30754,8 @@
     },
     "node_modules/ganache-core/node_modules/simple-concat": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
       "funding": [
         {
           "type": "github",
@@ -29481,6 +30775,8 @@
     },
     "node_modules/ganache-core/node_modules/simple-get": {
       "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
+      "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -29491,6 +30787,8 @@
     },
     "node_modules/ganache-core/node_modules/snapdragon": {
       "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+      "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
       "license": "MIT",
       "dependencies": {
         "base": "^0.11.1",
@@ -29508,6 +30806,8 @@
     },
     "node_modules/ganache-core/node_modules/snapdragon-node": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
       "license": "MIT",
       "dependencies": {
         "define-property": "^1.0.0",
@@ -29520,6 +30820,8 @@
     },
     "node_modules/ganache-core/node_modules/snapdragon-node/node_modules/define-property": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+      "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
       "license": "MIT",
       "dependencies": {
         "is-descriptor": "^1.0.0"
@@ -29530,6 +30832,8 @@
     },
     "node_modules/ganache-core/node_modules/snapdragon-util": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "license": "MIT",
       "dependencies": {
         "kind-of": "^3.2.0"
@@ -29540,10 +30844,14 @@
     },
     "node_modules/ganache-core/node_modules/snapdragon-util/node_modules/is-buffer": {
       "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/snapdragon-util/node_modules/kind-of": {
       "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "license": "MIT",
       "dependencies": {
         "is-buffer": "^1.1.5"
@@ -29554,6 +30862,8 @@
     },
     "node_modules/ganache-core/node_modules/snapdragon/node_modules/debug": {
       "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -29561,6 +30871,8 @@
     },
     "node_modules/ganache-core/node_modules/snapdragon/node_modules/define-property": {
       "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+      "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
       "license": "MIT",
       "dependencies": {
         "is-descriptor": "^0.1.0"
@@ -29571,6 +30883,8 @@
     },
     "node_modules/ganache-core/node_modules/snapdragon/node_modules/extend-shallow": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
       "license": "MIT",
       "dependencies": {
         "is-extendable": "^0.1.0"
@@ -29581,6 +30895,8 @@
     },
     "node_modules/ganache-core/node_modules/snapdragon/node_modules/is-accessor-descriptor": {
       "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "license": "MIT",
       "dependencies": {
         "kind-of": "^3.0.2"
@@ -29591,6 +30907,8 @@
     },
     "node_modules/ganache-core/node_modules/snapdragon/node_modules/is-accessor-descriptor/node_modules/kind-of": {
       "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "license": "MIT",
       "dependencies": {
         "is-buffer": "^1.1.5"
@@ -29601,10 +30919,14 @@
     },
     "node_modules/ganache-core/node_modules/snapdragon/node_modules/is-buffer": {
       "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/snapdragon/node_modules/is-data-descriptor": {
       "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "license": "MIT",
       "dependencies": {
         "kind-of": "^3.0.2"
@@ -29615,6 +30937,8 @@
     },
     "node_modules/ganache-core/node_modules/snapdragon/node_modules/is-data-descriptor/node_modules/kind-of": {
       "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "license": "MIT",
       "dependencies": {
         "is-buffer": "^1.1.5"
@@ -29625,6 +30949,8 @@
     },
     "node_modules/ganache-core/node_modules/snapdragon/node_modules/is-descriptor": {
       "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
       "license": "MIT",
       "dependencies": {
         "is-accessor-descriptor": "^0.1.6",
@@ -29637,6 +30963,8 @@
     },
     "node_modules/ganache-core/node_modules/snapdragon/node_modules/is-extendable": {
       "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -29644,6 +30972,8 @@
     },
     "node_modules/ganache-core/node_modules/snapdragon/node_modules/kind-of": {
       "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+      "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -29651,10 +30981,14 @@
     },
     "node_modules/ganache-core/node_modules/snapdragon/node_modules/ms": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/source-map": {
       "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -29662,6 +30996,8 @@
     },
     "node_modules/ganache-core/node_modules/source-map-resolve": {
       "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
+      "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
       "license": "MIT",
       "dependencies": {
         "atob": "^2.1.2",
@@ -29673,6 +31009,8 @@
     },
     "node_modules/ganache-core/node_modules/source-map-support": {
       "version": "0.5.12",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
+      "integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -29681,6 +31019,8 @@
     },
     "node_modules/ganache-core/node_modules/source-map-support/node_modules/source-map": {
       "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -29692,6 +31032,8 @@
     },
     "node_modules/ganache-core/node_modules/split-string": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "license": "MIT",
       "dependencies": {
         "extend-shallow": "^3.0.0"
@@ -29702,6 +31044,8 @@
     },
     "node_modules/ganache-core/node_modules/sshpk": {
       "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
       "license": "MIT",
       "dependencies": {
         "asn1": "~0.2.3",
@@ -29720,10 +31064,14 @@
     },
     "node_modules/ganache-core/node_modules/sshpk/node_modules/tweetnacl": {
       "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "license": "Unlicense"
     },
     "node_modules/ganache-core/node_modules/static-extend": {
       "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "license": "MIT",
       "dependencies": {
         "define-property": "^0.2.5",
@@ -29735,6 +31083,8 @@
     },
     "node_modules/ganache-core/node_modules/static-extend/node_modules/define-property": {
       "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+      "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
       "license": "MIT",
       "dependencies": {
         "is-descriptor": "^0.1.0"
@@ -29745,6 +31095,8 @@
     },
     "node_modules/ganache-core/node_modules/static-extend/node_modules/is-accessor-descriptor": {
       "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "license": "MIT",
       "dependencies": {
         "kind-of": "^3.0.2"
@@ -29755,6 +31107,8 @@
     },
     "node_modules/ganache-core/node_modules/static-extend/node_modules/is-accessor-descriptor/node_modules/kind-of": {
       "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "license": "MIT",
       "dependencies": {
         "is-buffer": "^1.1.5"
@@ -29765,10 +31119,14 @@
     },
     "node_modules/ganache-core/node_modules/static-extend/node_modules/is-buffer": {
       "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/static-extend/node_modules/is-data-descriptor": {
       "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "license": "MIT",
       "dependencies": {
         "kind-of": "^3.0.2"
@@ -29779,6 +31137,8 @@
     },
     "node_modules/ganache-core/node_modules/static-extend/node_modules/is-data-descriptor/node_modules/kind-of": {
       "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "license": "MIT",
       "dependencies": {
         "is-buffer": "^1.1.5"
@@ -29789,6 +31149,8 @@
     },
     "node_modules/ganache-core/node_modules/static-extend/node_modules/is-descriptor": {
       "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
       "license": "MIT",
       "dependencies": {
         "is-accessor-descriptor": "^0.1.6",
@@ -29801,6 +31163,8 @@
     },
     "node_modules/ganache-core/node_modules/static-extend/node_modules/kind-of": {
       "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+      "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -29808,6 +31172,8 @@
     },
     "node_modules/ganache-core/node_modules/statuses": {
       "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -29816,6 +31182,8 @@
     },
     "node_modules/ganache-core/node_modules/stream-to-pull-stream": {
       "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/stream-to-pull-stream/-/stream-to-pull-stream-1.7.3.tgz",
+      "integrity": "sha512-6sNyqJpr5dIOQdgNy/xcDWwDuzAsAwVzhzrWlAPAQ7Lkjx/rv0wgvxEyKwTq6FmNd5rjTrELt/CLmaSw7crMGg==",
       "license": "MIT",
       "dependencies": {
         "looper": "^3.0.0",
@@ -29824,10 +31192,14 @@
     },
     "node_modules/ganache-core/node_modules/stream-to-pull-stream/node_modules/looper": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/looper/-/looper-3.0.0.tgz",
+      "integrity": "sha1-LvpUw7HLq6m5Su4uWRSwvlf7t0k=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/strict-uri-encode": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -29836,6 +31208,8 @@
     },
     "node_modules/ganache-core/node_modules/string_decoder": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
@@ -29843,6 +31217,8 @@
     },
     "node_modules/ganache-core/node_modules/string_decoder/node_modules/safe-buffer": {
       "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/string.prototype.trim": {
@@ -29884,6 +31260,8 @@
     },
     "node_modules/ganache-core/node_modules/strip-hex-prefix": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz",
+      "integrity": "sha1-DF8VX+8RUTczd96du1iNoFUA428=",
       "license": "MIT",
       "dependencies": {
         "is-hex-prefixed": "1.0.0"
@@ -29895,6 +31273,8 @@
     },
     "node_modules/ganache-core/node_modules/supports-color": {
       "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "license": "MIT",
       "dependencies": {
         "has-flag": "^3.0.0"
@@ -29905,6 +31285,8 @@
     },
     "node_modules/ganache-core/node_modules/swarm-js": {
       "version": "0.1.40",
+      "resolved": "https://registry.npmjs.org/swarm-js/-/swarm-js-0.1.40.tgz",
+      "integrity": "sha512-yqiOCEoA4/IShXkY3WKwP5PvZhmoOOD8clsKA7EEcRILMkTEYHCQ21HDCAcVpmIxZq4LyZvWeRJ6quIyHk1caA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -29923,6 +31305,8 @@
     },
     "node_modules/ganache-core/node_modules/swarm-js/node_modules/fs-extra": {
       "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+      "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -29933,6 +31317,8 @@
     },
     "node_modules/ganache-core/node_modules/swarm-js/node_modules/get-stream": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -29941,6 +31327,8 @@
     },
     "node_modules/ganache-core/node_modules/swarm-js/node_modules/got": {
       "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
+      "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -29965,6 +31353,8 @@
     },
     "node_modules/ganache-core/node_modules/swarm-js/node_modules/is-stream": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -29973,6 +31363,8 @@
     },
     "node_modules/ganache-core/node_modules/swarm-js/node_modules/p-cancelable": {
       "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
+      "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -29981,6 +31373,8 @@
     },
     "node_modules/ganache-core/node_modules/swarm-js/node_modules/prepend-http": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -29989,6 +31383,8 @@
     },
     "node_modules/ganache-core/node_modules/swarm-js/node_modules/url-parse-lax": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+      "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -30097,6 +31493,8 @@
     },
     "node_modules/ganache-core/node_modules/tar/node_modules/minipass": {
       "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+      "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -30106,10 +31504,14 @@
     },
     "node_modules/ganache-core/node_modules/through": {
       "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/through2": {
       "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
       "license": "MIT",
       "dependencies": {
         "readable-stream": "~2.3.6",
@@ -30118,6 +31520,8 @@
     },
     "node_modules/ganache-core/node_modules/timed-out": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -30126,6 +31530,8 @@
     },
     "node_modules/ganache-core/node_modules/tmp": {
       "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
+      "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
       "license": "MIT",
       "dependencies": {
         "rimraf": "^2.6.3"
@@ -30136,6 +31542,8 @@
     },
     "node_modules/ganache-core/node_modules/to-object-path": {
       "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "license": "MIT",
       "dependencies": {
         "kind-of": "^3.0.2"
@@ -30146,10 +31554,14 @@
     },
     "node_modules/ganache-core/node_modules/to-object-path/node_modules/is-buffer": {
       "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/to-object-path/node_modules/kind-of": {
       "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "license": "MIT",
       "dependencies": {
         "is-buffer": "^1.1.5"
@@ -30160,6 +31572,8 @@
     },
     "node_modules/ganache-core/node_modules/to-readable-stream": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
+      "integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -30168,6 +31582,8 @@
     },
     "node_modules/ganache-core/node_modules/to-regex": {
       "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+      "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
       "license": "MIT",
       "dependencies": {
         "define-property": "^2.0.2",
@@ -30181,6 +31597,8 @@
     },
     "node_modules/ganache-core/node_modules/toidentifier": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -30189,6 +31607,8 @@
     },
     "node_modules/ganache-core/node_modules/tough-cookie": {
       "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "psl": "^1.1.28",
@@ -30200,6 +31620,8 @@
     },
     "node_modules/ganache-core/node_modules/trim-right": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -30207,6 +31629,8 @@
     },
     "node_modules/ganache-core/node_modules/tunnel-agent": {
       "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "license": "Apache-2.0",
       "dependencies": {
         "safe-buffer": "^5.0.1"
@@ -30217,18 +31641,26 @@
     },
     "node_modules/ganache-core/node_modules/tweetnacl": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
       "license": "Unlicense"
     },
     "node_modules/ganache-core/node_modules/tweetnacl-util": {
       "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/tweetnacl-util/-/tweetnacl-util-0.15.1.tgz",
+      "integrity": "sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw==",
       "license": "Unlicense"
     },
     "node_modules/ganache-core/node_modules/type": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
       "license": "ISC"
     },
     "node_modules/ganache-core/node_modules/type-is": {
       "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -30241,10 +31673,14 @@
     },
     "node_modules/ganache-core/node_modules/typedarray": {
       "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/typedarray-to-buffer": {
       "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
       "license": "MIT",
       "dependencies": {
         "is-typedarray": "^1.0.0"
@@ -30252,6 +31688,8 @@
     },
     "node_modules/ganache-core/node_modules/typewise": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typewise/-/typewise-1.0.3.tgz",
+      "integrity": "sha1-EGeTZUCvl5N8xdz5kiSG6fooRlE=",
       "license": "MIT",
       "dependencies": {
         "typewise-core": "^1.2.0"
@@ -30259,24 +31697,34 @@
     },
     "node_modules/ganache-core/node_modules/typewise-core": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/typewise-core/-/typewise-core-1.2.0.tgz",
+      "integrity": "sha1-l+uRgFx/VdL5QXSPpQ0xXZke8ZU=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/typewiselite": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/typewiselite/-/typewiselite-1.0.0.tgz",
+      "integrity": "sha1-yIgvobsQksBgBal/NO9chQjjZk4=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/ultron": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
+      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
       "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/underscore": {
       "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
+      "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==",
       "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/union-value": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
       "license": "MIT",
       "dependencies": {
         "arr-union": "^3.1.0",
@@ -30290,6 +31738,8 @@
     },
     "node_modules/ganache-core/node_modules/union-value/node_modules/is-extendable": {
       "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -30297,6 +31747,8 @@
     },
     "node_modules/ganache-core/node_modules/universalify": {
       "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "license": "MIT",
       "engines": {
         "node": ">= 4.0.0"
@@ -30304,6 +31756,8 @@
     },
     "node_modules/ganache-core/node_modules/unorm": {
       "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/unorm/-/unorm-1.6.0.tgz",
+      "integrity": "sha512-b2/KCUlYZUeA7JFUuRJZPUtr4gZvBh7tavtv4fvk4+KV9pfGiR6CQAQAWl49ZpR3ts2dk4FYkP7EIgDJoiOLDA==",
       "license": "MIT or GPL-2.0",
       "engines": {
         "node": ">= 0.4.0"
@@ -30311,6 +31765,8 @@
     },
     "node_modules/ganache-core/node_modules/unpipe": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -30319,6 +31775,8 @@
     },
     "node_modules/ganache-core/node_modules/unset-value": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "license": "MIT",
       "dependencies": {
         "has-value": "^0.3.1",
@@ -30330,6 +31788,8 @@
     },
     "node_modules/ganache-core/node_modules/unset-value/node_modules/has-value": {
       "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+      "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
       "license": "MIT",
       "dependencies": {
         "get-value": "^2.0.3",
@@ -30342,6 +31802,8 @@
     },
     "node_modules/ganache-core/node_modules/unset-value/node_modules/has-value/node_modules/isobject": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
       "license": "MIT",
       "dependencies": {
         "isarray": "1.0.0"
@@ -30352,6 +31814,8 @@
     },
     "node_modules/ganache-core/node_modules/unset-value/node_modules/has-values": {
       "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+      "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -30359,6 +31823,8 @@
     },
     "node_modules/ganache-core/node_modules/uri-js": {
       "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
@@ -30366,10 +31832,14 @@
     },
     "node_modules/ganache-core/node_modules/urix": {
       "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/url-parse-lax": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+      "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -30381,11 +31851,15 @@
     },
     "node_modules/ganache-core/node_modules/url-set-query": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/url-set-query/-/url-set-query-1.0.0.tgz",
+      "integrity": "sha1-AW6M/Xwg7gXK/neV6JK9BwL6ozk=",
       "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/url-to-options": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
+      "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k=",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -30394,6 +31868,8 @@
     },
     "node_modules/ganache-core/node_modules/use": {
       "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+      "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -30409,11 +31885,15 @@
     },
     "node_modules/ganache-core/node_modules/utf8": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
+      "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ==",
       "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/util-deprecate": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/util.promisify": {
@@ -30432,6 +31912,8 @@
     },
     "node_modules/ganache-core/node_modules/utils-merge": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -30440,6 +31922,8 @@
     },
     "node_modules/ganache-core/node_modules/uuid": {
       "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
       "license": "MIT",
       "bin": {
         "uuid": "bin/uuid"
@@ -30447,11 +31931,15 @@
     },
     "node_modules/ganache-core/node_modules/varint": {
       "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
+      "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow==",
       "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/vary": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -30460,6 +31948,8 @@
     },
     "node_modules/ganache-core/node_modules/verror": {
       "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "engines": [
         "node >=0.6.0"
       ],
@@ -30472,6 +31962,8 @@
     },
     "node_modules/ganache-core/node_modules/web3": {
       "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/web3/-/web3-1.2.11.tgz",
+      "integrity": "sha512-mjQ8HeU41G6hgOYm1pmeH0mRAeNKJGnJEUzDMoerkpw7QUQT4exVREgF1MYPvL/z6vAshOXei25LE/t/Bxl8yQ==",
       "hasInstallScript": true,
       "license": "LGPL-3.0",
       "optional": true,
@@ -30490,6 +31982,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-bzz": {
       "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.2.11.tgz",
+      "integrity": "sha512-XGpWUEElGypBjeFyUhTkiPXFbDVD6Nr/S5jznE3t8cWUA0FxRf1n3n/NuIZeb0H9RkN2Ctd/jNma/k8XGa3YKg==",
       "license": "LGPL-3.0",
       "optional": true,
       "dependencies": {
@@ -30509,6 +32003,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-core": {
       "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.2.11.tgz",
+      "integrity": "sha512-CN7MEYOY5ryo5iVleIWRE3a3cZqVaLlIbIzDPsvQRUfzYnvzZQRZBm9Mq+ttDi2STOOzc1MKylspz/o3yq/LjQ==",
       "license": "LGPL-3.0",
       "optional": true,
       "dependencies": {
@@ -30526,6 +32022,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-core-helpers": {
       "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.11.tgz",
+      "integrity": "sha512-PEPoAoZd5ME7UfbnCZBdzIerpe74GEvlwT4AjOmHeCVZoIFk7EqvOZDejJHt+feJA6kMVTdd0xzRNN295UhC1A==",
       "license": "LGPL-3.0",
       "optional": true,
       "dependencies": {
@@ -30539,6 +32037,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-core-method": {
       "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.2.11.tgz",
+      "integrity": "sha512-ff0q76Cde94HAxLDZ6DbdmKniYCQVtvuaYh+rtOUMB6kssa5FX0q3vPmixi7NPooFnbKmmZCM6NvXg4IreTPIw==",
       "license": "LGPL-3.0",
       "optional": true,
       "dependencies": {
@@ -30555,6 +32055,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-core-promievent": {
       "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.2.11.tgz",
+      "integrity": "sha512-il4McoDa/Ox9Agh4kyfQ8Ak/9ABYpnF8poBLL33R/EnxLsJOGQG2nZhkJa3I067hocrPSjEdlPt/0bHXsln4qA==",
       "license": "LGPL-3.0",
       "optional": true,
       "dependencies": {
@@ -30566,6 +32068,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-core-requestmanager": {
       "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.2.11.tgz",
+      "integrity": "sha512-oFhBtLfOiIbmfl6T6gYjjj9igOvtyxJ+fjS+byRxiwFJyJ5BQOz4/9/17gWR1Cq74paTlI7vDGxYfuvfE/mKvA==",
       "license": "LGPL-3.0",
       "optional": true,
       "dependencies": {
@@ -30581,6 +32085,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-core-subscriptions": {
       "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.2.11.tgz",
+      "integrity": "sha512-qEF/OVqkCvQ7MPs1JylIZCZkin0aKK9lDxpAtQ1F8niEDGFqn7DT8E/vzbIa0GsOjL2fZjDhWJsaW+BSoAW1gg==",
       "license": "LGPL-3.0",
       "optional": true,
       "dependencies": {
@@ -30599,6 +32105,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-eth": {
       "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.2.11.tgz",
+      "integrity": "sha512-REvxW1wJ58AgHPcXPJOL49d1K/dPmuw4LjPLBPStOVkQjzDTVmJEIsiLwn2YeuNDd4pfakBwT8L3bz1G1/wVsQ==",
       "license": "LGPL-3.0",
       "optional": true,
       "dependencies": {
@@ -30622,6 +32130,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-eth-abi": {
       "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.2.11.tgz",
+      "integrity": "sha512-PkRYc0+MjuLSgg03QVWqWlQivJqRwKItKtEpRUaxUAeLE7i/uU39gmzm2keHGcQXo3POXAbOnMqkDvOep89Crg==",
       "license": "LGPL-3.0",
       "optional": true,
       "dependencies": {
@@ -30635,6 +32145,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-eth-accounts": {
       "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.2.11.tgz",
+      "integrity": "sha512-6FwPqEpCfKIh3nSSGeo3uBm2iFSnFJDfwL3oS9pyegRBXNsGRVpgiW63yhNzL0796StsvjHWwQnQHsZNxWAkGw==",
       "license": "LGPL-3.0",
       "optional": true,
       "dependencies": {
@@ -30656,6 +32168,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-eth-accounts/node_modules/eth-lib": {
       "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+      "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -30666,6 +32180,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-eth-accounts/node_modules/uuid": {
       "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
       "license": "MIT",
       "optional": true,
       "bin": {
@@ -30674,6 +32190,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-eth-contract": {
       "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.2.11.tgz",
+      "integrity": "sha512-MzYuI/Rq2o6gn7vCGcnQgco63isPNK5lMAan2E51AJLknjSLnOxwNY3gM8BcKoy4Z+v5Dv00a03Xuk78JowFow==",
       "license": "LGPL-3.0",
       "optional": true,
       "dependencies": {
@@ -30693,6 +32211,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-eth-ens": {
       "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.2.11.tgz",
+      "integrity": "sha512-dbW7dXP6HqT1EAPvnniZVnmw6TmQEKF6/1KgAxbo8iBBYrVTMDGFQUUnZ+C4VETGrwwaqtX4L9d/FrQhZ6SUiA==",
       "license": "LGPL-3.0",
       "optional": true,
       "dependencies": {
@@ -30712,6 +32232,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-eth-iban": {
       "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.2.11.tgz",
+      "integrity": "sha512-ozuVlZ5jwFC2hJY4+fH9pIcuH1xP0HEFhtWsR69u9uDIANHLPQQtWYmdj7xQ3p2YT4bQLq/axKhZi7EZVetmxQ==",
       "license": "LGPL-3.0",
       "optional": true,
       "dependencies": {
@@ -30724,6 +32246,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-eth-personal": {
       "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.2.11.tgz",
+      "integrity": "sha512-42IzUtKq9iHZ8K9VN0vAI50iSU9tOA1V7XU2BhF/tb7We2iKBVdkley2fg26TxlOcKNEHm7o6HRtiiFsVK4Ifw==",
       "license": "LGPL-3.0",
       "optional": true,
       "dependencies": {
@@ -30745,6 +32269,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-net": {
       "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.2.11.tgz",
+      "integrity": "sha512-sjrSDj0pTfZouR5BSTItCuZ5K/oZPVdVciPQ6981PPPIwJJkCMeVjD7I4zO3qDPCnBjBSbWvVnLdwqUBPtHxyg==",
       "license": "LGPL-3.0",
       "optional": true,
       "dependencies": {
@@ -30758,6 +32284,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-provider-engine": {
       "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/web3-provider-engine/-/web3-provider-engine-14.2.1.tgz",
+      "integrity": "sha512-iSv31h2qXkr9vrL6UZDm4leZMc32SjWJFGOp/D92JXfcEboCqraZyuExDkpxKw8ziTufXieNM7LSXNHzszYdJw==",
       "license": "MIT",
       "dependencies": {
         "async": "^2.5.0",
@@ -30784,6 +32312,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/abstract-leveldown": {
       "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
+      "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
       "license": "MIT",
       "dependencies": {
         "xtend": "~4.0.0"
@@ -30791,6 +32321,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/deferred-leveldown": {
       "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz",
+      "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
       "license": "MIT",
       "dependencies": {
         "abstract-leveldown": "~2.6.0"
@@ -30806,6 +32338,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/ethereumjs-account": {
       "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/ethereumjs-account/-/ethereumjs-account-2.0.5.tgz",
+      "integrity": "sha512-bgDojnXGjhMwo6eXQC0bY6UK2liSFUSMwwylOmQvZbSl/D7NXQ3+vrGO46ZeOgjGfxXmgIeVNDIiHw7fNZM4VA==",
       "license": "MPL-2.0",
       "dependencies": {
         "ethereumjs-util": "^5.0.0",
@@ -30815,6 +32349,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/ethereumjs-block": {
       "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.7.1.tgz",
+      "integrity": "sha512-B+sSdtqm78fmKkBq78/QLKJbu/4Ts4P2KFISdgcuZUPDm9x+N7qgBPIIFUGbaakQh8bzuquiRVbdmvPKqbILRg==",
       "license": "MPL-2.0",
       "dependencies": {
         "async": "^2.0.1",
@@ -30826,10 +32362,14 @@
     },
     "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/ethereumjs-block/node_modules/ethereum-common": {
       "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.2.0.tgz",
+      "integrity": "sha512-XOnAR/3rntJgbCdGhqdaLIxDLWKLmsZOGhHdBKadEr6gEnJLH52k93Ou+TUdFaPN3hJc3isBZBal3U/XZ15abA==",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/ethereumjs-tx": {
       "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-1.3.7.tgz",
+      "integrity": "sha512-wvLMxzt1RPhAQ9Yi3/HKZTn0FZYpnsmQdbKYfUUpi4j1SEIcbkd9tndVjcPrufY3V7j2IebOpC00Zp2P/Ay2kA==",
       "license": "MPL-2.0",
       "dependencies": {
         "ethereum-common": "^0.0.18",
@@ -30838,6 +32378,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/ethereumjs-util": {
       "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+      "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
       "license": "MPL-2.0",
       "dependencies": {
         "bn.js": "^4.11.0",
@@ -30851,6 +32393,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/ethereumjs-vm": {
       "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-2.6.0.tgz",
+      "integrity": "sha512-r/XIUik/ynGbxS3y+mvGnbOKnuLo40V5Mj1J25+HEO63aWYREIqvWeRO/hnROlMBE5WoniQmPmhiaN0ctiHaXw==",
       "license": "MPL-2.0",
       "dependencies": {
         "async": "^2.1.2",
@@ -30868,6 +32412,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/ethereumjs-vm/node_modules/ethereumjs-block": {
       "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-2.2.2.tgz",
+      "integrity": "sha512-2p49ifhek3h2zeg/+da6XpdFR3GlqY3BIEiqxGF8j9aSRIgkb7M1Ky+yULBKJOu8PAZxfhsYA+HxUk2aCQp3vg==",
       "license": "MPL-2.0",
       "dependencies": {
         "async": "^2.0.1",
@@ -30879,6 +32425,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/ethereumjs-vm/node_modules/ethereumjs-block/node_modules/ethereumjs-util": {
       "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+      "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
       "license": "MPL-2.0",
       "dependencies": {
         "bn.js": "^4.11.0",
@@ -30892,6 +32440,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/ethereumjs-vm/node_modules/ethereumjs-tx": {
       "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-2.1.2.tgz",
+      "integrity": "sha512-zZEK1onCeiORb0wyCXUvg94Ve5It/K6GD1K+26KfFKodiBiS6d9lfCXlUKGBBdQ+bv7Day+JK0tj1K+BeNFRAw==",
       "license": "MPL-2.0",
       "dependencies": {
         "ethereumjs-common": "^1.5.0",
@@ -30900,6 +32450,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/ethereumjs-vm/node_modules/ethereumjs-util": {
       "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
+      "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
       "license": "MPL-2.0",
       "dependencies": {
         "@types/bn.js": "^4.11.3",
@@ -30913,14 +32465,20 @@
     },
     "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/isarray": {
       "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/level-codec": {
       "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-7.0.1.tgz",
+      "integrity": "sha512-Ua/R9B9r3RasXdRmOtd+t9TCOEIIlts+TN/7XTT2unhDaL6sJn83S3rUyljbr6lVtw49N3/yA0HHjpV6Kzb2aQ==",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/level-errors": {
       "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.5.tgz",
+      "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
       "license": "MIT",
       "dependencies": {
         "errno": "~0.1.1"
@@ -30928,6 +32486,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/level-iterator-stream": {
       "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
+      "integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.1",
@@ -30938,6 +32498,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/level-iterator-stream/node_modules/readable-stream": {
       "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -30948,6 +32510,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/level-ws": {
       "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/level-ws/-/level-ws-0.0.0.tgz",
+      "integrity": "sha1-Ny5RIXeSSgBCSwtDrvK7QkltIos=",
       "license": "MIT",
       "dependencies": {
         "readable-stream": "~1.0.15",
@@ -30956,6 +32520,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/level-ws/node_modules/readable-stream": {
       "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -30966,6 +32532,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/level-ws/node_modules/xtend": {
       "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+      "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
       "dependencies": {
         "object-keys": "~0.4.0"
       },
@@ -30975,6 +32543,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/levelup": {
       "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.9.tgz",
+      "integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
       "license": "MIT",
       "dependencies": {
         "deferred-leveldown": "~1.2.1",
@@ -30988,10 +32558,14 @@
     },
     "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/ltgt": {
       "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
+      "integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/memdown": {
       "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/memdown/-/memdown-1.4.1.tgz",
+      "integrity": "sha1-tOThkhdGZP+65BNhqlAPMRnv4hU=",
       "license": "MIT",
       "dependencies": {
         "abstract-leveldown": "~2.7.1",
@@ -31004,6 +32578,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/memdown/node_modules/abstract-leveldown": {
       "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
+      "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
       "license": "MIT",
       "dependencies": {
         "xtend": "~4.0.0"
@@ -31011,6 +32587,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/merkle-patricia-tree": {
       "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-2.3.2.tgz",
+      "integrity": "sha512-81PW5m8oz/pz3GvsAwbauj7Y00rqm81Tzad77tHBwU7pIAtN+TJnMSOJhxBKflSVYhptMMb9RskhqHqrSm1V+g==",
       "license": "MPL-2.0",
       "dependencies": {
         "async": "^1.4.2",
@@ -31025,18 +32603,26 @@
     },
     "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/merkle-patricia-tree/node_modules/async": {
       "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/object-keys": {
       "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+      "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/safe-buffer": {
       "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/semver": {
       "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver"
@@ -31044,6 +32630,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/string_decoder": {
       "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/ws": {
@@ -31055,6 +32643,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-providers-http": {
       "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.2.11.tgz",
+      "integrity": "sha512-psh4hYGb1+ijWywfwpB2cvvOIMISlR44F/rJtYkRmQ5jMvG4FOCPlQJPiHQZo+2cc3HbktvvSJzIhkWQJdmvrA==",
       "license": "LGPL-3.0",
       "optional": true,
       "dependencies": {
@@ -31067,6 +32657,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-providers-ipc": {
       "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.2.11.tgz",
+      "integrity": "sha512-yhc7Y/k8hBV/KlELxynWjJDzmgDEDjIjBzXK+e0rHBsYEhdCNdIH5Psa456c+l0qTEU2YzycF8VAjYpWfPnBpQ==",
       "license": "LGPL-3.0",
       "optional": true,
       "dependencies": {
@@ -31080,6 +32672,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-providers-ws": {
       "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.2.11.tgz",
+      "integrity": "sha512-ZxnjIY1Er8Ty+cE4migzr43zA/+72AF1myzsLaU5eVgdsfV7Jqx7Dix1hbevNZDKFlSoEyq/3j/jYalh3So1Zg==",
       "license": "LGPL-3.0",
       "optional": true,
       "dependencies": {
@@ -31094,6 +32688,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-shh": {
       "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.2.11.tgz",
+      "integrity": "sha512-B3OrO3oG1L+bv3E1sTwCx66injW1A8hhwpknDUbV+sw3fehFazA06z9SGXUefuFI1kVs4q2vRi0n4oCcI4dZDg==",
       "license": "LGPL-3.0",
       "optional": true,
       "dependencies": {
@@ -31108,6 +32704,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-utils": {
       "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.11.tgz",
+      "integrity": "sha512-3Tq09izhD+ThqHEaWYX4VOT7dNPdZiO+c/1QMA0s5X2lDFKK/xHJb7cyTRRVzN2LvlHbR7baS1tmQhSua51TcQ==",
       "license": "LGPL-3.0",
       "optional": true,
       "dependencies": {
@@ -31126,6 +32724,8 @@
     },
     "node_modules/ganache-core/node_modules/web3-utils/node_modules/eth-lib": {
       "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+      "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -31136,6 +32736,8 @@
     },
     "node_modules/ganache-core/node_modules/websocket": {
       "version": "1.0.32",
+      "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.32.tgz",
+      "integrity": "sha512-i4yhcllSP4wrpoPMU2N0TQ/q0O94LRG/eUQjEAamRltjQ1oT1PFFKOG4i877OlJgCG8rw6LrrowJp+TYCEWF7Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "bufferutil": "^4.0.1",
@@ -31151,6 +32753,8 @@
     },
     "node_modules/ganache-core/node_modules/websocket/node_modules/debug": {
       "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -31158,18 +32762,26 @@
     },
     "node_modules/ganache-core/node_modules/websocket/node_modules/ms": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/whatwg-fetch": {
       "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+      "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==",
       "license": "MIT"
     },
     "node_modules/ganache-core/node_modules/wrappy": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "license": "ISC"
     },
     "node_modules/ganache-core/node_modules/ws": {
       "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
+      "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -31180,11 +32792,15 @@
     },
     "node_modules/ganache-core/node_modules/ws/node_modules/safe-buffer": {
       "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT",
       "optional": true
     },
     "node_modules/ganache-core/node_modules/xhr": {
       "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.6.0.tgz",
+      "integrity": "sha512-/eCGLb5rxjx5e3mF1A7s+pLlR6CGyqWN91fv1JgER5mVWg1MZmlhBvy9kjcsOdRk8RrIujotWyJamfyrp+WIcA==",
       "license": "MIT",
       "dependencies": {
         "global": "~4.4.0",
@@ -31195,6 +32811,8 @@
     },
     "node_modules/ganache-core/node_modules/xhr-request": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/xhr-request/-/xhr-request-1.1.0.tgz",
+      "integrity": "sha512-Y7qzEaR3FDtL3fP30k9wO/e+FBnBByZeybKOhASsGP30NIkRAAkKD/sCnLvgEfAIEC1rcmK7YG8f4oEnIrrWzA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -31209,6 +32827,8 @@
     },
     "node_modules/ganache-core/node_modules/xhr-request-promise": {
       "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/xhr-request-promise/-/xhr-request-promise-0.1.3.tgz",
+      "integrity": "sha512-YUBytBsuwgitWtdRzXDDkWAXzhdGB8bYm0sSzMPZT7Z2MBjMSTHFsyCT1yCRATY+XC69DUrQraRAEgcoCRaIPg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -31217,6 +32837,8 @@
     },
     "node_modules/ganache-core/node_modules/xhr2-cookies": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/xhr2-cookies/-/xhr2-cookies-1.1.0.tgz",
+      "integrity": "sha1-fXdEnQmZGX8VXLc7I99yUF7YnUg=",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -31225,6 +32847,8 @@
     },
     "node_modules/ganache-core/node_modules/xtend": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.4"
@@ -31232,6 +32856,8 @@
     },
     "node_modules/ganache-core/node_modules/yaeti": {
       "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
+      "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc=",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.32"
@@ -31239,6 +32865,8 @@
     },
     "node_modules/ganache-core/node_modules/yallist": {
       "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "license": "ISC"
     },
     "node_modules/gauge": {
@@ -73093,6 +74721,8 @@
       "dependencies": {
         "@ethersproject/abi": {
           "version": "5.0.0-beta.153",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.0-beta.153.tgz",
+          "integrity": "sha512-aXweZ1Z7vMNzJdLpR1CZUAIgnwjrZeUSvN9syCwlBaEBUFJmFY+HHnfuTI5vIhVs/mRkfJVrbEyl51JZQqyjAg==",
           "optional": true,
           "requires": {
             "@ethersproject/address": ">=5.0.0-beta.128",
@@ -73266,10 +74896,14 @@
         },
         "@sindresorhus/is": {
           "version": "0.14.0",
+          "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
+          "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
           "optional": true
         },
         "@szmarczak/http-timer": {
           "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
+          "integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
           "optional": true,
           "requires": {
             "defer-to-connect": "^1.0.1"
@@ -73277,6 +74911,8 @@
         },
         "@types/bn.js": {
           "version": "4.11.6",
+          "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
+          "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
           "requires": {
             "@types/node": "*"
           }
@@ -73286,6 +74922,8 @@
         },
         "@types/pbkdf2": {
           "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@types/pbkdf2/-/pbkdf2-3.1.0.tgz",
+          "integrity": "sha512-Cf63Rv7jCQ0LaL8tNXmEyqTHuIJxRdlS5vMh1mj5voN4+QFhVZnlZruezqpWYDiJ8UTzhP0VmeLXCmBk66YrMQ==",
           "requires": {
             "@types/node": "*"
           }
@@ -73297,16 +74935,22 @@
           }
         },
         "@yarnpkg/lockfile": {
-          "version": "1.1.0"
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+          "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ=="
         },
         "abstract-leveldown": {
           "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-3.0.0.tgz",
+          "integrity": "sha512-KUWx9UWGQD12zsmLNj64/pndaz4iJh/Pj7nopgkfDG6RlCcbMZvT6+9l7dchK4idog2Is8VdC/PvNbFuFmalIQ==",
           "requires": {
             "xtend": "~4.0.0"
           }
         },
         "accepts": {
           "version": "1.3.7",
+          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
+          "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
           "optional": true,
           "requires": {
             "mime-types": "~2.1.24",
@@ -73315,10 +74959,14 @@
         },
         "aes-js": {
           "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.1.2.tgz",
+          "integrity": "sha512-e5pEa2kBnBOgR4Y/p20pskXI74UEz7de8ZGVo58asOtvSVG5YAbJeELPZxOmt+Bnz3rX753YKhfIn4X4l1PPRQ==",
           "optional": true
         },
         "ajv": {
           "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -73328,34 +74976,50 @@
         },
         "ansi-styles": {
           "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
             "color-convert": "^1.9.0"
           }
         },
         "arr-diff": {
-          "version": "4.0.0"
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
         },
         "arr-flatten": {
-          "version": "1.1.0"
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+          "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
         },
         "arr-union": {
-          "version": "3.1.0"
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+          "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
         },
         "array-flatten": {
           "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+          "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
           "optional": true
         },
         "array-unique": {
-          "version": "0.3.2"
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
         },
         "asn1": {
           "version": "0.2.4",
+          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+          "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
           "requires": {
             "safer-buffer": "~2.1.0"
           }
         },
         "asn1.js": {
           "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+          "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
           "optional": true,
           "requires": {
             "bn.js": "^4.0.0",
@@ -73365,40 +75029,60 @@
           }
         },
         "assert-plus": {
-          "version": "1.0.0"
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         },
         "assign-symbols": {
-          "version": "1.0.0"
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+          "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
         },
         "async": {
           "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
+          "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
           "requires": {
             "lodash": "^4.17.11"
           }
         },
         "async-eventemitter": {
           "version": "0.2.4",
+          "resolved": "https://registry.npmjs.org/async-eventemitter/-/async-eventemitter-0.2.4.tgz",
+          "integrity": "sha512-pd20BwL7Yt1zwDFy+8MX8F1+WCT8aQeKj0kQnTrH9WaeRETlRamVhD0JtRPmrV4GfOJ2F9CvdQkZeZhnh2TuHw==",
           "requires": {
             "async": "^2.4.0"
           }
         },
         "async-limiter": {
-          "version": "1.0.1"
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+          "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
         },
         "asynckit": {
-          "version": "0.4.0"
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+          "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
         },
         "atob": {
-          "version": "2.1.2"
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+          "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
         },
         "aws-sign2": {
-          "version": "0.7.0"
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+          "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
         },
         "aws4": {
-          "version": "1.11.0"
+          "version": "1.11.0",
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
+          "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
         },
         "babel-code-frame": {
           "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+          "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
           "requires": {
             "chalk": "^1.1.3",
             "esutils": "^2.0.2",
@@ -73406,13 +75090,19 @@
           },
           "dependencies": {
             "ansi-regex": {
-              "version": "2.1.1"
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
             },
             "ansi-styles": {
-              "version": "2.2.1"
+              "version": "2.2.1",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
             },
             "chalk": {
               "version": "1.1.3",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
               "requires": {
                 "ansi-styles": "^2.2.1",
                 "escape-string-regexp": "^1.0.2",
@@ -73422,21 +75112,29 @@
               }
             },
             "js-tokens": {
-              "version": "3.0.2"
+              "version": "3.0.2",
+              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+              "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
             },
             "strip-ansi": {
               "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
             },
             "supports-color": {
-              "version": "2.0.0"
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
             }
           }
         },
         "babel-core": {
           "version": "6.26.3",
+          "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
+          "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
           "requires": {
             "babel-code-frame": "^6.26.0",
             "babel-generator": "^6.26.0",
@@ -73461,23 +75159,33 @@
           "dependencies": {
             "debug": {
               "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
               "requires": {
                 "ms": "2.0.0"
               }
             },
             "json5": {
-              "version": "0.5.1"
+              "version": "0.5.1",
+              "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+              "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
             },
             "ms": {
-              "version": "2.0.0"
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
             },
             "slash": {
-              "version": "1.0.0"
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+              "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
             }
           }
         },
         "babel-generator": {
           "version": "6.26.1",
+          "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
+          "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
           "requires": {
             "babel-messages": "^6.23.0",
             "babel-runtime": "^6.26.0",
@@ -73490,12 +75198,16 @@
           },
           "dependencies": {
             "jsesc": {
-              "version": "1.3.0"
+              "version": "1.3.0",
+              "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+              "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
             }
           }
         },
         "babel-helper-builder-binary-assignment-operator-visitor": {
           "version": "6.24.1",
+          "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
+          "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
           "requires": {
             "babel-helper-explode-assignable-expression": "^6.24.1",
             "babel-runtime": "^6.22.0",
@@ -73504,6 +75216,8 @@
         },
         "babel-helper-call-delegate": {
           "version": "6.24.1",
+          "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
+          "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
           "requires": {
             "babel-helper-hoist-variables": "^6.24.1",
             "babel-runtime": "^6.22.0",
@@ -73513,6 +75227,8 @@
         },
         "babel-helper-define-map": {
           "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
+          "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
           "requires": {
             "babel-helper-function-name": "^6.24.1",
             "babel-runtime": "^6.26.0",
@@ -73522,6 +75238,8 @@
         },
         "babel-helper-explode-assignable-expression": {
           "version": "6.24.1",
+          "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
+          "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
           "requires": {
             "babel-runtime": "^6.22.0",
             "babel-traverse": "^6.24.1",
@@ -73530,6 +75248,8 @@
         },
         "babel-helper-function-name": {
           "version": "6.24.1",
+          "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+          "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
           "requires": {
             "babel-helper-get-function-arity": "^6.24.1",
             "babel-runtime": "^6.22.0",
@@ -73540,6 +75260,8 @@
         },
         "babel-helper-get-function-arity": {
           "version": "6.24.1",
+          "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+          "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
           "requires": {
             "babel-runtime": "^6.22.0",
             "babel-types": "^6.24.1"
@@ -73547,6 +75269,8 @@
         },
         "babel-helper-hoist-variables": {
           "version": "6.24.1",
+          "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
+          "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
           "requires": {
             "babel-runtime": "^6.22.0",
             "babel-types": "^6.24.1"
@@ -73554,6 +75278,8 @@
         },
         "babel-helper-optimise-call-expression": {
           "version": "6.24.1",
+          "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
+          "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
           "requires": {
             "babel-runtime": "^6.22.0",
             "babel-types": "^6.24.1"
@@ -73561,6 +75287,8 @@
         },
         "babel-helper-regex": {
           "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
+          "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
           "requires": {
             "babel-runtime": "^6.26.0",
             "babel-types": "^6.26.0",
@@ -73569,6 +75297,8 @@
         },
         "babel-helper-remap-async-to-generator": {
           "version": "6.24.1",
+          "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
+          "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
           "requires": {
             "babel-helper-function-name": "^6.24.1",
             "babel-runtime": "^6.22.0",
@@ -73579,6 +75309,8 @@
         },
         "babel-helper-replace-supers": {
           "version": "6.24.1",
+          "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
+          "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
           "requires": {
             "babel-helper-optimise-call-expression": "^6.24.1",
             "babel-messages": "^6.23.0",
@@ -73590,6 +75322,8 @@
         },
         "babel-helpers": {
           "version": "6.24.1",
+          "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+          "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
           "requires": {
             "babel-runtime": "^6.22.0",
             "babel-template": "^6.24.1"
@@ -73597,27 +75331,39 @@
         },
         "babel-messages": {
           "version": "6.23.0",
+          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+          "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
           "requires": {
             "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-check-es2015-constants": {
           "version": "6.22.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
+          "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
           "requires": {
             "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-syntax-async-functions": {
-          "version": "6.13.0"
+          "version": "6.13.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
+          "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
         },
         "babel-plugin-syntax-exponentiation-operator": {
-          "version": "6.13.0"
+          "version": "6.13.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
+          "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
         },
         "babel-plugin-syntax-trailing-function-commas": {
-          "version": "6.22.0"
+          "version": "6.22.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
+          "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM="
         },
         "babel-plugin-transform-async-to-generator": {
           "version": "6.24.1",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
+          "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
           "requires": {
             "babel-helper-remap-async-to-generator": "^6.24.1",
             "babel-plugin-syntax-async-functions": "^6.8.0",
@@ -73626,18 +75372,24 @@
         },
         "babel-plugin-transform-es2015-arrow-functions": {
           "version": "6.22.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
+          "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
           "requires": {
             "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-es2015-block-scoped-functions": {
           "version": "6.22.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
+          "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
           "requires": {
             "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-es2015-block-scoping": {
           "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
+          "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
           "requires": {
             "babel-runtime": "^6.26.0",
             "babel-template": "^6.26.0",
@@ -73648,6 +75400,8 @@
         },
         "babel-plugin-transform-es2015-classes": {
           "version": "6.24.1",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
+          "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
           "requires": {
             "babel-helper-define-map": "^6.24.1",
             "babel-helper-function-name": "^6.24.1",
@@ -73662,6 +75416,8 @@
         },
         "babel-plugin-transform-es2015-computed-properties": {
           "version": "6.24.1",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
+          "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
           "requires": {
             "babel-runtime": "^6.22.0",
             "babel-template": "^6.24.1"
@@ -73669,12 +75425,16 @@
         },
         "babel-plugin-transform-es2015-destructuring": {
           "version": "6.23.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+          "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
           "requires": {
             "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-es2015-duplicate-keys": {
           "version": "6.24.1",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
+          "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
           "requires": {
             "babel-runtime": "^6.22.0",
             "babel-types": "^6.24.1"
@@ -73682,12 +75442,16 @@
         },
         "babel-plugin-transform-es2015-for-of": {
           "version": "6.23.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
+          "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
           "requires": {
             "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-es2015-function-name": {
           "version": "6.24.1",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
+          "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
           "requires": {
             "babel-helper-function-name": "^6.24.1",
             "babel-runtime": "^6.22.0",
@@ -73696,12 +75460,16 @@
         },
         "babel-plugin-transform-es2015-literals": {
           "version": "6.22.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
+          "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
           "requires": {
             "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-es2015-modules-amd": {
           "version": "6.24.1",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
+          "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
           "requires": {
             "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
             "babel-runtime": "^6.22.0",
@@ -73710,6 +75478,8 @@
         },
         "babel-plugin-transform-es2015-modules-commonjs": {
           "version": "6.26.2",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
+          "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
           "requires": {
             "babel-plugin-transform-strict-mode": "^6.24.1",
             "babel-runtime": "^6.26.0",
@@ -73719,6 +75489,8 @@
         },
         "babel-plugin-transform-es2015-modules-systemjs": {
           "version": "6.24.1",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
+          "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
           "requires": {
             "babel-helper-hoist-variables": "^6.24.1",
             "babel-runtime": "^6.22.0",
@@ -73727,6 +75499,8 @@
         },
         "babel-plugin-transform-es2015-modules-umd": {
           "version": "6.24.1",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
+          "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
           "requires": {
             "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
             "babel-runtime": "^6.22.0",
@@ -73735,6 +75509,8 @@
         },
         "babel-plugin-transform-es2015-object-super": {
           "version": "6.24.1",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
+          "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
           "requires": {
             "babel-helper-replace-supers": "^6.24.1",
             "babel-runtime": "^6.22.0"
@@ -73742,6 +75518,8 @@
         },
         "babel-plugin-transform-es2015-parameters": {
           "version": "6.24.1",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
+          "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
           "requires": {
             "babel-helper-call-delegate": "^6.24.1",
             "babel-helper-get-function-arity": "^6.24.1",
@@ -73753,6 +75531,8 @@
         },
         "babel-plugin-transform-es2015-shorthand-properties": {
           "version": "6.24.1",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
+          "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
           "requires": {
             "babel-runtime": "^6.22.0",
             "babel-types": "^6.24.1"
@@ -73760,12 +75540,16 @@
         },
         "babel-plugin-transform-es2015-spread": {
           "version": "6.22.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
+          "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
           "requires": {
             "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-es2015-sticky-regex": {
           "version": "6.24.1",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
+          "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
           "requires": {
             "babel-helper-regex": "^6.24.1",
             "babel-runtime": "^6.22.0",
@@ -73774,18 +75558,24 @@
         },
         "babel-plugin-transform-es2015-template-literals": {
           "version": "6.22.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
+          "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
           "requires": {
             "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-es2015-typeof-symbol": {
           "version": "6.23.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
+          "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
           "requires": {
             "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-es2015-unicode-regex": {
           "version": "6.24.1",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
+          "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
           "requires": {
             "babel-helper-regex": "^6.24.1",
             "babel-runtime": "^6.22.0",
@@ -73794,6 +75584,8 @@
         },
         "babel-plugin-transform-exponentiation-operator": {
           "version": "6.24.1",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
+          "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
           "requires": {
             "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
             "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
@@ -73802,12 +75594,16 @@
         },
         "babel-plugin-transform-regenerator": {
           "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
+          "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
           "requires": {
             "regenerator-transform": "^0.10.0"
           }
         },
         "babel-plugin-transform-strict-mode": {
           "version": "6.24.1",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
+          "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
           "requires": {
             "babel-runtime": "^6.22.0",
             "babel-types": "^6.24.1"
@@ -73815,6 +75611,8 @@
         },
         "babel-preset-env": {
           "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.7.0.tgz",
+          "integrity": "sha512-9OR2afuKDneX2/q2EurSftUYM0xGu4O2D9adAhVfADDhrYDaxXV0rBbevVYoY9n6nyX1PmQW/0jtpJvUNr9CHg==",
           "requires": {
             "babel-plugin-check-es2015-constants": "^6.22.0",
             "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
@@ -73849,12 +75647,16 @@
           },
           "dependencies": {
             "semver": {
-              "version": "5.7.1"
+              "version": "5.7.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
             }
           }
         },
         "babel-register": {
           "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
+          "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
           "requires": {
             "babel-core": "^6.26.0",
             "babel-runtime": "^6.26.0",
@@ -73867,6 +75669,8 @@
           "dependencies": {
             "source-map-support": {
               "version": "0.4.18",
+              "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+              "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
               "requires": {
                 "source-map": "^0.5.6"
               }
@@ -73875,6 +75679,8 @@
         },
         "babel-runtime": {
           "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+          "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
           "requires": {
             "core-js": "^2.4.0",
             "regenerator-runtime": "^0.11.0"
@@ -73882,6 +75688,8 @@
         },
         "babel-template": {
           "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+          "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
           "requires": {
             "babel-runtime": "^6.26.0",
             "babel-traverse": "^6.26.0",
@@ -73892,6 +75700,8 @@
         },
         "babel-traverse": {
           "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+          "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
           "requires": {
             "babel-code-frame": "^6.26.0",
             "babel-messages": "^6.23.0",
@@ -73906,20 +75716,28 @@
           "dependencies": {
             "debug": {
               "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
               "requires": {
                 "ms": "2.0.0"
               }
             },
             "globals": {
-              "version": "9.18.0"
+              "version": "9.18.0",
+              "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+              "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
             },
             "ms": {
-              "version": "2.0.0"
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
             }
           }
         },
         "babel-types": {
           "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+          "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
           "requires": {
             "babel-runtime": "^6.26.0",
             "esutils": "^2.0.2",
@@ -73928,22 +75746,30 @@
           },
           "dependencies": {
             "to-fast-properties": {
-              "version": "1.0.3"
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+              "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
             }
           }
         },
         "babelify": {
           "version": "7.3.0",
+          "resolved": "https://registry.npmjs.org/babelify/-/babelify-7.3.0.tgz",
+          "integrity": "sha1-qlau3nBn/XvVSWZu4W3ChQh+iOU=",
           "requires": {
             "babel-core": "^6.0.14",
             "object-assign": "^4.0.0"
           }
         },
         "babylon": {
-          "version": "6.18.0"
+          "version": "6.18.0",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
         },
         "backoff": {
           "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.5.0.tgz",
+          "integrity": "sha1-9hbtqdPktmuMp/ynn2lXIsX44m8=",
           "requires": {
             "precond": "0.2"
           }
@@ -73953,6 +75779,8 @@
         },
         "base": {
           "version": "0.11.2",
+          "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+          "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
           "requires": {
             "cache-base": "^1.0.1",
             "class-utils": "^0.3.5",
@@ -73965,6 +75793,8 @@
           "dependencies": {
             "define-property": {
               "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "requires": {
                 "is-descriptor": "^1.0.0"
               }
@@ -73973,30 +75803,42 @@
         },
         "base-x": {
           "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
+          "integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
           "requires": {
             "safe-buffer": "^5.0.1"
           }
         },
         "base64-js": {
-          "version": "1.5.1"
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+          "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
         },
         "bcrypt-pbkdf": {
           "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+          "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
           "requires": {
             "tweetnacl": "^0.14.3"
           },
           "dependencies": {
             "tweetnacl": {
-              "version": "0.14.5"
+              "version": "0.14.5",
+              "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+              "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
             }
           }
         },
         "bignumber.js": {
           "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
+          "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA==",
           "optional": true
         },
         "bip39": {
           "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/bip39/-/bip39-2.5.0.tgz",
+          "integrity": "sha512-xwIx/8JKoT2+IPJpFEfXoWdYwP7UVAoUxxLNfGCfVowaJE7yg1Y5B1BVPqlUNsBq5/nGwmFkwRJ8xDW4sX8OdA==",
           "requires": {
             "create-hash": "^1.1.0",
             "pbkdf2": "^3.0.9",
@@ -74010,6 +75852,8 @@
         },
         "bluebird": {
           "version": "3.7.2",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+          "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
           "optional": true
         },
         "bn.js": {
@@ -74017,6 +75861,8 @@
         },
         "body-parser": {
           "version": "1.19.0",
+          "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
+          "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
           "optional": true,
           "requires": {
             "bytes": "3.1.0",
@@ -74033,6 +75879,8 @@
           "dependencies": {
             "debug": {
               "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
               "optional": true,
               "requires": {
                 "ms": "2.0.0"
@@ -74040,26 +75888,36 @@
             },
             "ms": {
               "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
               "optional": true
             },
             "qs": {
               "version": "6.7.0",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+              "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
               "optional": true
             }
           }
         },
         "brace-expansion": {
           "version": "1.1.11",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
         "brorand": {
-          "version": "1.1.0"
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+          "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
         },
         "browserify-aes": {
           "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+          "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
           "requires": {
             "buffer-xor": "^1.0.3",
             "cipher-base": "^1.0.0",
@@ -74071,6 +75929,8 @@
         },
         "browserify-cipher": {
           "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+          "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
           "optional": true,
           "requires": {
             "browserify-aes": "^1.0.4",
@@ -74080,6 +75940,8 @@
         },
         "browserify-des": {
           "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
+          "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
           "optional": true,
           "requires": {
             "cipher-base": "^1.0.1",
@@ -74090,6 +75952,8 @@
         },
         "browserify-rsa": {
           "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.0.tgz",
+          "integrity": "sha512-AdEER0Hkspgno2aR97SAf6vi0y0k8NuOpGnVH3O99rcA5Q6sh8QxcngtHuJ6uXwnfAXNM4Gn1Gb7/MV1+Ymbog==",
           "optional": true,
           "requires": {
             "bn.js": "^5.0.0",
@@ -74104,6 +75968,8 @@
         },
         "browserify-sign": {
           "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.1.tgz",
+          "integrity": "sha512-/vrA5fguVAKKAVTNJjgSm1tRQDHUU6DbwO9IROu/0WAzC8PKhucDSh18J0RMvVeHAn5puMd+QHC2erPRNf8lmg==",
           "optional": true,
           "requires": {
             "bn.js": "^5.1.1",
@@ -74123,6 +75989,8 @@
             },
             "readable-stream": {
               "version": "3.6.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+              "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
               "optional": true,
               "requires": {
                 "inherits": "^2.0.3",
@@ -74134,6 +76002,8 @@
         },
         "browserslist": {
           "version": "3.2.8",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.8.tgz",
+          "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
           "requires": {
             "caniuse-lite": "^1.0.30000844",
             "electron-to-chromium": "^1.3.47"
@@ -74141,12 +76011,16 @@
         },
         "bs58": {
           "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+          "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
           "requires": {
             "base-x": "^3.0.2"
           }
         },
         "bs58check": {
           "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
+          "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
           "requires": {
             "bs58": "^4.0.0",
             "create-hash": "^1.1.0",
@@ -74155,6 +76029,8 @@
         },
         "buffer": {
           "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
           "requires": {
             "base64-js": "^1.3.1",
             "ieee754": "^1.1.13"
@@ -74165,23 +76041,33 @@
         },
         "buffer-to-arraybuffer": {
           "version": "0.0.5",
+          "resolved": "https://registry.npmjs.org/buffer-to-arraybuffer/-/buffer-to-arraybuffer-0.0.5.tgz",
+          "integrity": "sha1-YGSkD6dutDxyOrqe+PbhIW0QURo=",
           "optional": true
         },
         "buffer-xor": {
-          "version": "1.0.3"
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+          "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
         },
         "bufferutil": {
           "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.3.tgz",
+          "integrity": "sha512-yEYTwGndELGvfXsImMBLop58eaGW+YdONi1fNjTINSY98tmMmFijBG6WXgdkfuLNt4imzQNtIE+eBp1PVpMCSw==",
           "requires": {
             "node-gyp-build": "^4.2.0"
           }
         },
         "bytes": {
           "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+          "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
           "optional": true
         },
         "bytewise": {
           "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/bytewise/-/bytewise-1.1.0.tgz",
+          "integrity": "sha1-HRPL/3F65xWAlKqIGzXQgbOHJT4=",
           "requires": {
             "bytewise-core": "^1.2.2",
             "typewise": "^1.0.3"
@@ -74189,12 +76075,16 @@
         },
         "bytewise-core": {
           "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/bytewise-core/-/bytewise-core-1.2.3.tgz",
+          "integrity": "sha1-P7QQx+kVWOsasiqCg0V3qmvWHUI=",
           "requires": {
             "typewise-core": "^1.2"
           }
         },
         "cache-base": {
           "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+          "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
           "requires": {
             "collection-visit": "^1.0.0",
             "component-emitter": "^1.2.1",
@@ -74209,6 +76099,8 @@
         },
         "cacheable-request": {
           "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
+          "integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
           "optional": true,
           "requires": {
             "clone-response": "^1.0.2",
@@ -74222,12 +76114,16 @@
           "dependencies": {
             "lowercase-keys": {
               "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+              "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
               "optional": true
             }
           }
         },
         "cachedown": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/cachedown/-/cachedown-1.0.0.tgz",
+          "integrity": "sha1-1D8DbkUQaWsxJG19sx6/D3rDLRU=",
           "requires": {
             "abstract-leveldown": "^2.4.1",
             "lru-cache": "^3.2.0"
@@ -74235,12 +76131,16 @@
           "dependencies": {
             "abstract-leveldown": {
               "version": "2.7.2",
+              "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
+              "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
               "requires": {
                 "xtend": "~4.0.0"
               }
             },
             "lru-cache": {
               "version": "3.2.0",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-3.2.0.tgz",
+              "integrity": "sha1-cXibO39Tmb7IVl3aOKow0qCX7+4=",
               "requires": {
                 "pseudomap": "^1.0.1"
               }
@@ -74249,6 +76149,8 @@
         },
         "call-bind": {
           "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+          "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
           "requires": {
             "function-bind": "^1.1.1",
             "get-intrinsic": "^1.0.2"
@@ -74258,10 +76160,14 @@
           "version": "1.0.30001174"
         },
         "caseless": {
-          "version": "0.12.0"
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
         },
         "chalk": {
           "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
@@ -74270,19 +76176,27 @@
         },
         "checkpoint-store": {
           "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/checkpoint-store/-/checkpoint-store-1.1.0.tgz",
+          "integrity": "sha1-BOTLUWuRQziTWB5tRgGnjpVS6gY=",
           "requires": {
             "functional-red-black-tree": "^1.0.1"
           }
         },
         "chownr": {
           "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+          "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
           "optional": true
         },
         "ci-info": {
-          "version": "2.0.0"
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+          "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
         },
         "cids": {
           "version": "0.7.5",
+          "resolved": "https://registry.npmjs.org/cids/-/cids-0.7.5.tgz",
+          "integrity": "sha512-zT7mPeghoWAu+ppn8+BS1tQ5qGmbMfB4AregnQjA/qHY3GC1m1ptI9GkWNlgeu38r7CuRdXB47uY2XgAYt6QVA==",
           "optional": true,
           "requires": {
             "buffer": "^5.5.0",
@@ -74294,6 +76208,8 @@
           "dependencies": {
             "multicodec": {
               "version": "1.0.4",
+              "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
+              "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
               "optional": true,
               "requires": {
                 "buffer": "^5.6.0",
@@ -74304,6 +76220,8 @@
         },
         "cipher-base": {
           "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+          "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
           "requires": {
             "inherits": "^2.0.1",
             "safe-buffer": "^5.0.1"
@@ -74311,10 +76229,14 @@
         },
         "class-is": {
           "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/class-is/-/class-is-1.1.0.tgz",
+          "integrity": "sha512-rhjH9AG1fvabIDoGRVH587413LPjTZgmDF9fOFCbFJQV4yuocX1mHxxvXI4g3cGwbVY9wAYIoKlg1N79frJKQw==",
           "optional": true
         },
         "class-utils": {
           "version": "0.3.6",
+          "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+          "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
           "requires": {
             "arr-union": "^3.1.0",
             "define-property": "^0.2.5",
@@ -74324,18 +76246,24 @@
           "dependencies": {
             "define-property": {
               "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "requires": {
                 "is-descriptor": "^0.1.0"
               }
             },
             "is-accessor-descriptor": {
               "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+              "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
               "requires": {
                 "kind-of": "^3.0.2"
               },
               "dependencies": {
                 "kind-of": {
                   "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "requires": {
                     "is-buffer": "^1.1.5"
                   }
@@ -74343,16 +76271,22 @@
               }
             },
             "is-buffer": {
-              "version": "1.1.6"
+              "version": "1.1.6",
+              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+              "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
             },
             "is-data-descriptor": {
               "version": "0.1.4",
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+              "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
               "requires": {
                 "kind-of": "^3.0.2"
               },
               "dependencies": {
                 "kind-of": {
                   "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "requires": {
                     "is-buffer": "^1.1.5"
                   }
@@ -74361,6 +76295,8 @@
             },
             "is-descriptor": {
               "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "requires": {
                 "is-accessor-descriptor": "^0.1.6",
                 "is-data-descriptor": "^0.1.4",
@@ -74368,15 +76304,21 @@
               }
             },
             "kind-of": {
-              "version": "5.1.0"
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
             }
           }
         },
         "clone": {
-          "version": "2.1.2"
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+          "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
         },
         "clone-response": {
           "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
+          "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
           "optional": true,
           "requires": {
             "mimic-response": "^1.0.0"
@@ -74384,6 +76326,8 @@
         },
         "collection-visit": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+          "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
           "requires": {
             "map-visit": "^1.0.0",
             "object-visit": "^1.0.0"
@@ -74391,27 +76335,39 @@
         },
         "color-convert": {
           "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
           "requires": {
             "color-name": "1.1.3"
           }
         },
         "color-name": {
-          "version": "1.1.3"
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
         },
         "combined-stream": {
           "version": "1.0.8",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+          "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
           "requires": {
             "delayed-stream": "~1.0.0"
           }
         },
         "component-emitter": {
-          "version": "1.3.0"
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+          "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
         },
         "concat-map": {
-          "version": "0.0.1"
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "concat-stream": {
           "version": "1.6.2",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+          "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
           "requires": {
             "buffer-from": "^1.0.0",
             "inherits": "^2.0.3",
@@ -74421,6 +76377,8 @@
         },
         "content-disposition": {
           "version": "0.5.3",
+          "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
+          "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
           "optional": true,
           "requires": {
             "safe-buffer": "5.1.2"
@@ -74428,12 +76386,16 @@
           "dependencies": {
             "safe-buffer": {
               "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
               "optional": true
             }
           }
         },
         "content-hash": {
           "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/content-hash/-/content-hash-2.5.2.tgz",
+          "integrity": "sha512-FvIQKy0S1JaWV10sMsA7TRx8bpU+pqPkhbsfvOJAdjRXvYxEckAwQWGwtRjiaJfh+E0DvcWUGqcdjwMGFjsSdw==",
           "optional": true,
           "requires": {
             "cids": "^0.7.1",
@@ -74443,6 +76405,8 @@
         },
         "content-type": {
           "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+          "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
           "optional": true
         },
         "convert-source-map": {
@@ -74452,36 +76416,52 @@
           },
           "dependencies": {
             "safe-buffer": {
-              "version": "5.1.2"
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
             }
           }
         },
         "cookie": {
           "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+          "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
           "optional": true
         },
         "cookie-signature": {
           "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+          "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
           "optional": true
         },
         "cookiejar": {
           "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
+          "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==",
           "optional": true
         },
         "copy-descriptor": {
-          "version": "0.1.1"
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+          "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
         },
         "core-js": {
-          "version": "2.6.12"
+          "version": "2.6.12",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+          "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
         },
         "core-js-pure": {
           "version": "3.8.2"
         },
         "core-util-is": {
-          "version": "1.0.2"
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
         },
         "cors": {
           "version": "2.8.5",
+          "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+          "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
           "optional": true,
           "requires": {
             "object-assign": "^4",
@@ -74490,6 +76470,8 @@
         },
         "create-ecdh": {
           "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
+          "integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
           "optional": true,
           "requires": {
             "bn.js": "^4.1.0",
@@ -74498,6 +76480,8 @@
         },
         "create-hash": {
           "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+          "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
           "requires": {
             "cipher-base": "^1.0.1",
             "inherits": "^2.0.1",
@@ -74508,6 +76492,8 @@
         },
         "create-hmac": {
           "version": "1.1.7",
+          "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+          "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
           "requires": {
             "cipher-base": "^1.0.3",
             "create-hash": "^1.1.0",
@@ -74526,6 +76512,8 @@
         },
         "crypto-browserify": {
           "version": "3.12.0",
+          "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+          "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
           "optional": true,
           "requires": {
             "browserify-cipher": "^1.0.0",
@@ -74543,6 +76531,8 @@
         },
         "d": {
           "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+          "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
           "requires": {
             "es5-ext": "^0.10.50",
             "type": "^1.0.1"
@@ -74550,21 +76540,29 @@
         },
         "dashdash": {
           "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
           "requires": {
             "assert-plus": "^1.0.0"
           }
         },
         "debug": {
           "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "requires": {
             "ms": "^2.1.1"
           }
         },
         "decode-uri-component": {
-          "version": "0.2.0"
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+          "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
         },
         "decompress-response": {
           "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+          "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
           "optional": true,
           "requires": {
             "mimic-response": "^1.0.0"
@@ -74572,6 +76570,8 @@
         },
         "deep-equal": {
           "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
+          "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
           "requires": {
             "is-arguments": "^1.0.4",
             "is-date-object": "^1.0.1",
@@ -74583,10 +76583,14 @@
         },
         "defer-to-connect": {
           "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
+          "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==",
           "optional": true
         },
         "deferred-leveldown": {
           "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-4.0.2.tgz",
+          "integrity": "sha512-5fMC8ek8alH16QiV0lTCis610D1Zt1+LA4MS4d63JgS32lrCjTFDUFz2ao09/j2I4Bqb5jL4FZYwu7Jz0XO1ww==",
           "requires": {
             "abstract-leveldown": "~5.0.0",
             "inherits": "^2.0.3"
@@ -74594,6 +76598,8 @@
           "dependencies": {
             "abstract-leveldown": {
               "version": "5.0.0",
+              "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-5.0.0.tgz",
+              "integrity": "sha512-5mU5P1gXtsMIXg65/rsYGsi93+MlogXZ9FA8JnwKurHQg64bfXwGYVdVdijNTVNOlAsuIiOwHdvFFD5JqCJQ7A==",
               "requires": {
                 "xtend": "~4.0.0"
               }
@@ -74602,29 +76608,41 @@
         },
         "define-properties": {
           "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+          "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
           "requires": {
             "object-keys": "^1.0.12"
           }
         },
         "define-property": {
           "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+          "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
           "requires": {
             "is-descriptor": "^1.0.2",
             "isobject": "^3.0.1"
           }
         },
         "defined": {
-          "version": "1.0.0"
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+          "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
         },
         "delayed-stream": {
-          "version": "1.0.0"
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
         },
         "depd": {
           "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+          "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
           "optional": true
         },
         "des.js": {
           "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
+          "integrity": "sha512-Q0I4pfFrv2VPd34/vfLrFOoRmlYj3OV50i7fskps1jZWK1kApMWWT9G6RRUeYedLcBDIhnSDaUvJMb3AhUlaEA==",
           "optional": true,
           "requires": {
             "inherits": "^2.0.1",
@@ -74633,16 +76651,22 @@
         },
         "destroy": {
           "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+          "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
           "optional": true
         },
         "detect-indent": {
           "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+          "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
           "requires": {
             "repeating": "^2.0.0"
           }
         },
         "diffie-hellman": {
           "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+          "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
           "optional": true,
           "requires": {
             "bn.js": "^4.1.0",
@@ -74651,20 +76675,28 @@
           }
         },
         "dom-walk": {
-          "version": "0.1.2"
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
+          "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
         },
         "dotignore": {
           "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/dotignore/-/dotignore-0.1.2.tgz",
+          "integrity": "sha512-UGGGWfSauusaVJC+8fgV+NVvBXkCTmVv7sk6nojDZZvuOUNGUy0Zk4UpHQD6EDjS0jpBwcACvH4eofvyzBcRDw==",
           "requires": {
             "minimatch": "^3.0.4"
           }
         },
         "duplexer3": {
           "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+          "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
           "optional": true
         },
         "ecc-jsbn": {
           "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+          "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
           "requires": {
             "jsbn": "~0.1.0",
             "safer-buffer": "^2.1.0"
@@ -74672,6 +76704,8 @@
         },
         "ee-first": {
           "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+          "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
           "optional": true
         },
         "electron-to-chromium": {
@@ -74691,10 +76725,14 @@
         },
         "encodeurl": {
           "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+          "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
           "optional": true
         },
         "encoding": {
           "version": "0.1.13",
+          "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+          "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
           "requires": {
             "iconv-lite": "^0.6.2"
           },
@@ -74709,6 +76747,8 @@
         },
         "encoding-down": {
           "version": "5.0.4",
+          "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-5.0.4.tgz",
+          "integrity": "sha512-8CIZLDcSKxgzT+zX8ZVfgNbu8Md2wq/iqa1Y7zyVR18QBEAc0Nmzuvj/N5ykSKpfGzjM8qxbaFntLPwnVoUhZw==",
           "requires": {
             "abstract-leveldown": "^5.0.0",
             "inherits": "^2.0.3",
@@ -74719,6 +76759,8 @@
           "dependencies": {
             "abstract-leveldown": {
               "version": "5.0.0",
+              "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-5.0.0.tgz",
+              "integrity": "sha512-5mU5P1gXtsMIXg65/rsYGsi93+MlogXZ9FA8JnwKurHQg64bfXwGYVdVdijNTVNOlAsuIiOwHdvFFD5JqCJQ7A==",
               "requires": {
                 "xtend": "~4.0.0"
               }
@@ -74727,12 +76769,16 @@
         },
         "end-of-stream": {
           "version": "1.4.4",
+          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+          "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
           "requires": {
             "once": "^1.4.0"
           }
         },
         "errno": {
           "version": "0.1.8",
+          "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
+          "integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
           "requires": {
             "prr": "~1.0.1"
           }
@@ -74756,6 +76802,8 @@
         },
         "es-to-primitive": {
           "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+          "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
           "requires": {
             "is-callable": "^1.1.4",
             "is-date-object": "^1.0.1",
@@ -74764,6 +76812,8 @@
         },
         "es5-ext": {
           "version": "0.10.53",
+          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
+          "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
           "requires": {
             "es6-iterator": "~2.0.3",
             "es6-symbol": "~3.1.3",
@@ -74772,6 +76822,8 @@
         },
         "es6-iterator": {
           "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+          "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
           "requires": {
             "d": "1",
             "es5-ext": "^0.10.35",
@@ -74780,6 +76832,8 @@
         },
         "es6-symbol": {
           "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+          "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
           "requires": {
             "d": "^1.0.1",
             "ext": "^1.1.2"
@@ -74787,20 +76841,30 @@
         },
         "escape-html": {
           "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+          "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
           "optional": true
         },
         "escape-string-regexp": {
-          "version": "1.0.5"
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
         },
         "esutils": {
-          "version": "2.0.3"
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+          "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
         },
         "etag": {
           "version": "1.8.1",
+          "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+          "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
           "optional": true
         },
         "eth-block-tracker": {
           "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/eth-block-tracker/-/eth-block-tracker-3.0.1.tgz",
+          "integrity": "sha512-WUVxWLuhMmsfenfZvFO5sbl1qFY2IqUlw/FPVmjjdElpqLsZtSG+wPe9Dz7W/sB6e80HgFKknOmKk2eNlznHug==",
           "requires": {
             "eth-query": "^2.1.0",
             "ethereumjs-tx": "^1.3.3",
@@ -74813,6 +76877,8 @@
           "dependencies": {
             "ethereumjs-tx": {
               "version": "1.3.7",
+              "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-1.3.7.tgz",
+              "integrity": "sha512-wvLMxzt1RPhAQ9Yi3/HKZTn0FZYpnsmQdbKYfUUpi4j1SEIcbkd9tndVjcPrufY3V7j2IebOpC00Zp2P/Ay2kA==",
               "requires": {
                 "ethereum-common": "^0.0.18",
                 "ethereumjs-util": "^5.0.0"
@@ -74820,6 +76886,8 @@
             },
             "ethereumjs-util": {
               "version": "5.2.1",
+              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+              "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
               "requires": {
                 "bn.js": "^4.11.0",
                 "create-hash": "^1.1.2",
@@ -74831,12 +76899,16 @@
               }
             },
             "pify": {
-              "version": "2.3.0"
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
             }
           }
         },
         "eth-ens-namehash": {
           "version": "2.0.8",
+          "resolved": "https://registry.npmjs.org/eth-ens-namehash/-/eth-ens-namehash-2.0.8.tgz",
+          "integrity": "sha1-IprEbsqG1S4MmR58sq74P/D2i88=",
           "optional": true,
           "requires": {
             "idna-uts46-hx": "^2.3.1",
@@ -74845,6 +76917,8 @@
         },
         "eth-json-rpc-infura": {
           "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/eth-json-rpc-infura/-/eth-json-rpc-infura-3.2.1.tgz",
+          "integrity": "sha512-W7zR4DZvyTn23Bxc0EWsq4XGDdD63+XPUCEhV2zQvQGavDVC4ZpFDK4k99qN7bd7/fjj37+rxmuBOBeIqCA5Mw==",
           "requires": {
             "cross-fetch": "^2.1.1",
             "eth-json-rpc-middleware": "^1.5.0",
@@ -74854,6 +76928,8 @@
         },
         "eth-json-rpc-middleware": {
           "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/eth-json-rpc-middleware/-/eth-json-rpc-middleware-1.6.0.tgz",
+          "integrity": "sha512-tDVCTlrUvdqHKqivYMjtFZsdD7TtpNLBCfKAcOpaVs7orBMS/A8HWro6dIzNtTZIR05FAbJ3bioFOnZpuCew9Q==",
           "requires": {
             "async": "^2.5.0",
             "eth-query": "^2.1.2",
@@ -74872,18 +76948,24 @@
           "dependencies": {
             "abstract-leveldown": {
               "version": "2.6.3",
+              "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
+              "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
               "requires": {
                 "xtend": "~4.0.0"
               }
             },
             "deferred-leveldown": {
               "version": "1.2.2",
+              "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz",
+              "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
               "requires": {
                 "abstract-leveldown": "~2.6.0"
               }
             },
             "ethereumjs-account": {
               "version": "2.0.5",
+              "resolved": "https://registry.npmjs.org/ethereumjs-account/-/ethereumjs-account-2.0.5.tgz",
+              "integrity": "sha512-bgDojnXGjhMwo6eXQC0bY6UK2liSFUSMwwylOmQvZbSl/D7NXQ3+vrGO46ZeOgjGfxXmgIeVNDIiHw7fNZM4VA==",
               "requires": {
                 "ethereumjs-util": "^5.0.0",
                 "rlp": "^2.0.0",
@@ -74892,6 +76974,8 @@
             },
             "ethereumjs-block": {
               "version": "1.7.1",
+              "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.7.1.tgz",
+              "integrity": "sha512-B+sSdtqm78fmKkBq78/QLKJbu/4Ts4P2KFISdgcuZUPDm9x+N7qgBPIIFUGbaakQh8bzuquiRVbdmvPKqbILRg==",
               "requires": {
                 "async": "^2.0.1",
                 "ethereum-common": "0.2.0",
@@ -74901,12 +76985,16 @@
               },
               "dependencies": {
                 "ethereum-common": {
-                  "version": "0.2.0"
+                  "version": "0.2.0",
+                  "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.2.0.tgz",
+                  "integrity": "sha512-XOnAR/3rntJgbCdGhqdaLIxDLWKLmsZOGhHdBKadEr6gEnJLH52k93Ou+TUdFaPN3hJc3isBZBal3U/XZ15abA=="
                 }
               }
             },
             "ethereumjs-tx": {
               "version": "1.3.7",
+              "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-1.3.7.tgz",
+              "integrity": "sha512-wvLMxzt1RPhAQ9Yi3/HKZTn0FZYpnsmQdbKYfUUpi4j1SEIcbkd9tndVjcPrufY3V7j2IebOpC00Zp2P/Ay2kA==",
               "requires": {
                 "ethereum-common": "^0.0.18",
                 "ethereumjs-util": "^5.0.0"
@@ -74914,6 +77002,8 @@
             },
             "ethereumjs-util": {
               "version": "5.2.1",
+              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+              "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
               "requires": {
                 "bn.js": "^4.11.0",
                 "create-hash": "^1.1.2",
@@ -74926,6 +77016,8 @@
             },
             "ethereumjs-vm": {
               "version": "2.6.0",
+              "resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-2.6.0.tgz",
+              "integrity": "sha512-r/XIUik/ynGbxS3y+mvGnbOKnuLo40V5Mj1J25+HEO63aWYREIqvWeRO/hnROlMBE5WoniQmPmhiaN0ctiHaXw==",
               "requires": {
                 "async": "^2.1.2",
                 "async-eventemitter": "^0.2.2",
@@ -74942,6 +77034,8 @@
               "dependencies": {
                 "ethereumjs-block": {
                   "version": "2.2.2",
+                  "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-2.2.2.tgz",
+                  "integrity": "sha512-2p49ifhek3h2zeg/+da6XpdFR3GlqY3BIEiqxGF8j9aSRIgkb7M1Ky+yULBKJOu8PAZxfhsYA+HxUk2aCQp3vg==",
                   "requires": {
                     "async": "^2.0.1",
                     "ethereumjs-common": "^1.5.0",
@@ -74952,6 +77046,8 @@
                   "dependencies": {
                     "ethereumjs-util": {
                       "version": "5.2.1",
+                      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+                      "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
                       "requires": {
                         "bn.js": "^4.11.0",
                         "create-hash": "^1.1.2",
@@ -74966,6 +77062,8 @@
                 },
                 "ethereumjs-tx": {
                   "version": "2.1.2",
+                  "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-2.1.2.tgz",
+                  "integrity": "sha512-zZEK1onCeiORb0wyCXUvg94Ve5It/K6GD1K+26KfFKodiBiS6d9lfCXlUKGBBdQ+bv7Day+JK0tj1K+BeNFRAw==",
                   "requires": {
                     "ethereumjs-common": "^1.5.0",
                     "ethereumjs-util": "^6.0.0"
@@ -74973,6 +77071,8 @@
                 },
                 "ethereumjs-util": {
                   "version": "6.2.1",
+                  "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
+                  "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
                   "requires": {
                     "@types/bn.js": "^4.11.3",
                     "bn.js": "^4.11.0",
@@ -74986,19 +77086,27 @@
               }
             },
             "isarray": {
-              "version": "0.0.1"
+              "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
             },
             "level-codec": {
-              "version": "7.0.1"
+              "version": "7.0.1",
+              "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-7.0.1.tgz",
+              "integrity": "sha512-Ua/R9B9r3RasXdRmOtd+t9TCOEIIlts+TN/7XTT2unhDaL6sJn83S3rUyljbr6lVtw49N3/yA0HHjpV6Kzb2aQ=="
             },
             "level-errors": {
               "version": "1.0.5",
+              "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.5.tgz",
+              "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
               "requires": {
                 "errno": "~0.1.1"
               }
             },
             "level-iterator-stream": {
               "version": "1.3.1",
+              "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
+              "integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
               "requires": {
                 "inherits": "^2.0.1",
                 "level-errors": "^1.0.3",
@@ -75008,6 +77116,8 @@
               "dependencies": {
                 "readable-stream": {
                   "version": "1.1.14",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+                  "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
                   "requires": {
                     "core-util-is": "~1.0.0",
                     "inherits": "~2.0.1",
@@ -75019,6 +77129,8 @@
             },
             "level-ws": {
               "version": "0.0.0",
+              "resolved": "https://registry.npmjs.org/level-ws/-/level-ws-0.0.0.tgz",
+              "integrity": "sha1-Ny5RIXeSSgBCSwtDrvK7QkltIos=",
               "requires": {
                 "readable-stream": "~1.0.15",
                 "xtend": "~2.1.1"
@@ -75026,6 +77138,8 @@
               "dependencies": {
                 "readable-stream": {
                   "version": "1.0.34",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                  "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                   "requires": {
                     "core-util-is": "~1.0.0",
                     "inherits": "~2.0.1",
@@ -75035,6 +77149,8 @@
                 },
                 "xtend": {
                   "version": "2.1.2",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+                  "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
                   "requires": {
                     "object-keys": "~0.4.0"
                   }
@@ -75043,6 +77159,8 @@
             },
             "levelup": {
               "version": "1.3.9",
+              "resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.9.tgz",
+              "integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
               "requires": {
                 "deferred-leveldown": "~1.2.1",
                 "level-codec": "~7.0.0",
@@ -75054,10 +77172,14 @@
               }
             },
             "ltgt": {
-              "version": "2.2.1"
+              "version": "2.2.1",
+              "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
+              "integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU="
             },
             "memdown": {
               "version": "1.4.1",
+              "resolved": "https://registry.npmjs.org/memdown/-/memdown-1.4.1.tgz",
+              "integrity": "sha1-tOThkhdGZP+65BNhqlAPMRnv4hU=",
               "requires": {
                 "abstract-leveldown": "~2.7.1",
                 "functional-red-black-tree": "^1.0.1",
@@ -75069,6 +77191,8 @@
               "dependencies": {
                 "abstract-leveldown": {
                   "version": "2.7.2",
+                  "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
+                  "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
                   "requires": {
                     "xtend": "~4.0.0"
                   }
@@ -75077,6 +77201,8 @@
             },
             "merkle-patricia-tree": {
               "version": "2.3.2",
+              "resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-2.3.2.tgz",
+              "integrity": "sha512-81PW5m8oz/pz3GvsAwbauj7Y00rqm81Tzad77tHBwU7pIAtN+TJnMSOJhxBKflSVYhptMMb9RskhqHqrSm1V+g==",
               "requires": {
                 "async": "^1.4.2",
                 "ethereumjs-util": "^5.0.0",
@@ -75089,26 +77215,38 @@
               },
               "dependencies": {
                 "async": {
-                  "version": "1.5.2"
+                  "version": "1.5.2",
+                  "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+                  "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
                 }
               }
             },
             "object-keys": {
-              "version": "0.4.0"
+              "version": "0.4.0",
+              "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+              "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY="
             },
             "safe-buffer": {
-              "version": "5.1.2"
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
             },
             "semver": {
-              "version": "5.4.1"
+              "version": "5.4.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+              "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
             },
             "string_decoder": {
-              "version": "0.10.31"
+              "version": "0.10.31",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
             }
           }
         },
         "eth-lib": {
           "version": "0.1.29",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.1.29.tgz",
+          "integrity": "sha512-bfttrr3/7gG4E02HoWTDUcDDslN003OlOoBxk9virpAZQ1ja/jDgwkWB8QfJF7ojuEowrqy+lzp9VcJG7/k5bQ==",
           "optional": true,
           "requires": {
             "bn.js": "^4.11.6",
@@ -75121,6 +77259,8 @@
         },
         "eth-query": {
           "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/eth-query/-/eth-query-2.1.2.tgz",
+          "integrity": "sha1-1nQdkAAQa1FRDHLbktY2VFam2l4=",
           "requires": {
             "json-rpc-random-id": "^1.0.0",
             "xtend": "^4.0.1"
@@ -75128,6 +77268,8 @@
         },
         "eth-sig-util": {
           "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-3.0.0.tgz",
+          "integrity": "sha512-4eFkMOhpGbTxBQ3AMzVf0haUX2uTur7DpWiHzWyTURa28BVJJtOkcb9Ok5TV0YvEPG61DODPW7ZUATbJTslioQ==",
           "requires": {
             "buffer": "^5.2.1",
             "elliptic": "^6.4.0",
@@ -75139,6 +77281,8 @@
           "dependencies": {
             "ethereumjs-abi": {
               "version": "0.6.5",
+              "resolved": "https://registry.npmjs.org/ethereumjs-abi/-/ethereumjs-abi-0.6.5.tgz",
+              "integrity": "sha1-WmN+8Wq0NHP6cqKa2QhxQFs/UkE=",
               "requires": {
                 "bn.js": "^4.10.0",
                 "ethereumjs-util": "^4.3.0"
@@ -75146,6 +77290,8 @@
               "dependencies": {
                 "ethereumjs-util": {
                   "version": "4.5.1",
+                  "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.1.tgz",
+                  "integrity": "sha512-WrckOZ7uBnei4+AKimpuF1B3Fv25OmoRgmYCpGsP7u8PFxXAmAgiJSYT2kRWnt6fVIlKaQlZvuwXp7PIrmn3/w==",
                   "requires": {
                     "bn.js": "^4.8.0",
                     "create-hash": "^1.1.2",
@@ -75158,6 +77304,8 @@
             },
             "ethereumjs-util": {
               "version": "5.2.1",
+              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+              "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
               "requires": {
                 "bn.js": "^4.11.0",
                 "create-hash": "^1.1.2",
@@ -75172,6 +77320,8 @@
         },
         "eth-tx-summary": {
           "version": "3.2.4",
+          "resolved": "https://registry.npmjs.org/eth-tx-summary/-/eth-tx-summary-3.2.4.tgz",
+          "integrity": "sha512-NtlDnaVZah146Rm8HMRUNMgIwG/ED4jiqk0TME9zFheMl1jOp6jL1m0NKGjJwehXQ6ZKCPr16MTr+qspKpEXNg==",
           "requires": {
             "async": "^2.1.2",
             "clone": "^2.0.0",
@@ -75187,18 +77337,24 @@
           "dependencies": {
             "abstract-leveldown": {
               "version": "2.6.3",
+              "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
+              "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
               "requires": {
                 "xtend": "~4.0.0"
               }
             },
             "deferred-leveldown": {
               "version": "1.2.2",
+              "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz",
+              "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
               "requires": {
                 "abstract-leveldown": "~2.6.0"
               }
             },
             "ethereumjs-account": {
               "version": "2.0.5",
+              "resolved": "https://registry.npmjs.org/ethereumjs-account/-/ethereumjs-account-2.0.5.tgz",
+              "integrity": "sha512-bgDojnXGjhMwo6eXQC0bY6UK2liSFUSMwwylOmQvZbSl/D7NXQ3+vrGO46ZeOgjGfxXmgIeVNDIiHw7fNZM4VA==",
               "requires": {
                 "ethereumjs-util": "^5.0.0",
                 "rlp": "^2.0.0",
@@ -75207,6 +77363,8 @@
             },
             "ethereumjs-block": {
               "version": "1.7.1",
+              "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.7.1.tgz",
+              "integrity": "sha512-B+sSdtqm78fmKkBq78/QLKJbu/4Ts4P2KFISdgcuZUPDm9x+N7qgBPIIFUGbaakQh8bzuquiRVbdmvPKqbILRg==",
               "requires": {
                 "async": "^2.0.1",
                 "ethereum-common": "0.2.0",
@@ -75216,12 +77374,16 @@
               },
               "dependencies": {
                 "ethereum-common": {
-                  "version": "0.2.0"
+                  "version": "0.2.0",
+                  "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.2.0.tgz",
+                  "integrity": "sha512-XOnAR/3rntJgbCdGhqdaLIxDLWKLmsZOGhHdBKadEr6gEnJLH52k93Ou+TUdFaPN3hJc3isBZBal3U/XZ15abA=="
                 }
               }
             },
             "ethereumjs-tx": {
               "version": "1.3.7",
+              "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-1.3.7.tgz",
+              "integrity": "sha512-wvLMxzt1RPhAQ9Yi3/HKZTn0FZYpnsmQdbKYfUUpi4j1SEIcbkd9tndVjcPrufY3V7j2IebOpC00Zp2P/Ay2kA==",
               "requires": {
                 "ethereum-common": "^0.0.18",
                 "ethereumjs-util": "^5.0.0"
@@ -75229,6 +77391,8 @@
             },
             "ethereumjs-util": {
               "version": "5.2.1",
+              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+              "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
               "requires": {
                 "bn.js": "^4.11.0",
                 "create-hash": "^1.1.2",
@@ -75241,6 +77405,8 @@
             },
             "ethereumjs-vm": {
               "version": "2.6.0",
+              "resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-2.6.0.tgz",
+              "integrity": "sha512-r/XIUik/ynGbxS3y+mvGnbOKnuLo40V5Mj1J25+HEO63aWYREIqvWeRO/hnROlMBE5WoniQmPmhiaN0ctiHaXw==",
               "requires": {
                 "async": "^2.1.2",
                 "async-eventemitter": "^0.2.2",
@@ -75257,6 +77423,8 @@
               "dependencies": {
                 "ethereumjs-block": {
                   "version": "2.2.2",
+                  "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-2.2.2.tgz",
+                  "integrity": "sha512-2p49ifhek3h2zeg/+da6XpdFR3GlqY3BIEiqxGF8j9aSRIgkb7M1Ky+yULBKJOu8PAZxfhsYA+HxUk2aCQp3vg==",
                   "requires": {
                     "async": "^2.0.1",
                     "ethereumjs-common": "^1.5.0",
@@ -75267,6 +77435,8 @@
                   "dependencies": {
                     "ethereumjs-util": {
                       "version": "5.2.1",
+                      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+                      "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
                       "requires": {
                         "bn.js": "^4.11.0",
                         "create-hash": "^1.1.2",
@@ -75281,6 +77451,8 @@
                 },
                 "ethereumjs-tx": {
                   "version": "2.1.2",
+                  "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-2.1.2.tgz",
+                  "integrity": "sha512-zZEK1onCeiORb0wyCXUvg94Ve5It/K6GD1K+26KfFKodiBiS6d9lfCXlUKGBBdQ+bv7Day+JK0tj1K+BeNFRAw==",
                   "requires": {
                     "ethereumjs-common": "^1.5.0",
                     "ethereumjs-util": "^6.0.0"
@@ -75288,6 +77460,8 @@
                 },
                 "ethereumjs-util": {
                   "version": "6.2.1",
+                  "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
+                  "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
                   "requires": {
                     "@types/bn.js": "^4.11.3",
                     "bn.js": "^4.11.0",
@@ -75301,19 +77475,27 @@
               }
             },
             "isarray": {
-              "version": "0.0.1"
+              "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
             },
             "level-codec": {
-              "version": "7.0.1"
+              "version": "7.0.1",
+              "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-7.0.1.tgz",
+              "integrity": "sha512-Ua/R9B9r3RasXdRmOtd+t9TCOEIIlts+TN/7XTT2unhDaL6sJn83S3rUyljbr6lVtw49N3/yA0HHjpV6Kzb2aQ=="
             },
             "level-errors": {
               "version": "1.0.5",
+              "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.5.tgz",
+              "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
               "requires": {
                 "errno": "~0.1.1"
               }
             },
             "level-iterator-stream": {
               "version": "1.3.1",
+              "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
+              "integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
               "requires": {
                 "inherits": "^2.0.1",
                 "level-errors": "^1.0.3",
@@ -75323,6 +77505,8 @@
               "dependencies": {
                 "readable-stream": {
                   "version": "1.1.14",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+                  "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
                   "requires": {
                     "core-util-is": "~1.0.0",
                     "inherits": "~2.0.1",
@@ -75334,6 +77518,8 @@
             },
             "level-ws": {
               "version": "0.0.0",
+              "resolved": "https://registry.npmjs.org/level-ws/-/level-ws-0.0.0.tgz",
+              "integrity": "sha1-Ny5RIXeSSgBCSwtDrvK7QkltIos=",
               "requires": {
                 "readable-stream": "~1.0.15",
                 "xtend": "~2.1.1"
@@ -75341,6 +77527,8 @@
               "dependencies": {
                 "readable-stream": {
                   "version": "1.0.34",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                  "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                   "requires": {
                     "core-util-is": "~1.0.0",
                     "inherits": "~2.0.1",
@@ -75350,6 +77538,8 @@
                 },
                 "xtend": {
                   "version": "2.1.2",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+                  "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
                   "requires": {
                     "object-keys": "~0.4.0"
                   }
@@ -75358,6 +77548,8 @@
             },
             "levelup": {
               "version": "1.3.9",
+              "resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.9.tgz",
+              "integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
               "requires": {
                 "deferred-leveldown": "~1.2.1",
                 "level-codec": "~7.0.0",
@@ -75369,10 +77561,14 @@
               }
             },
             "ltgt": {
-              "version": "2.2.1"
+              "version": "2.2.1",
+              "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
+              "integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU="
             },
             "memdown": {
               "version": "1.4.1",
+              "resolved": "https://registry.npmjs.org/memdown/-/memdown-1.4.1.tgz",
+              "integrity": "sha1-tOThkhdGZP+65BNhqlAPMRnv4hU=",
               "requires": {
                 "abstract-leveldown": "~2.7.1",
                 "functional-red-black-tree": "^1.0.1",
@@ -75384,6 +77580,8 @@
               "dependencies": {
                 "abstract-leveldown": {
                   "version": "2.7.2",
+                  "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
+                  "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
                   "requires": {
                     "xtend": "~4.0.0"
                   }
@@ -75392,6 +77590,8 @@
             },
             "merkle-patricia-tree": {
               "version": "2.3.2",
+              "resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-2.3.2.tgz",
+              "integrity": "sha512-81PW5m8oz/pz3GvsAwbauj7Y00rqm81Tzad77tHBwU7pIAtN+TJnMSOJhxBKflSVYhptMMb9RskhqHqrSm1V+g==",
               "requires": {
                 "async": "^1.4.2",
                 "ethereumjs-util": "^5.0.0",
@@ -75404,26 +77604,38 @@
               },
               "dependencies": {
                 "async": {
-                  "version": "1.5.2"
+                  "version": "1.5.2",
+                  "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+                  "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
                 }
               }
             },
             "object-keys": {
-              "version": "0.4.0"
+              "version": "0.4.0",
+              "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+              "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY="
             },
             "safe-buffer": {
-              "version": "5.1.2"
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
             },
             "semver": {
-              "version": "5.4.1"
+              "version": "5.4.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+              "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
             },
             "string_decoder": {
-              "version": "0.10.31"
+              "version": "0.10.31",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
             }
           }
         },
         "ethashjs": {
           "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/ethashjs/-/ethashjs-0.0.8.tgz",
+          "integrity": "sha512-/MSbf/r2/Ld8o0l15AymjOTlPqpN8Cr4ByUEA9GtR4x0yAh3TdtDzEg29zMjXCNPI7u6E5fOQdj/Cf9Tc7oVNw==",
           "requires": {
             "async": "^2.1.2",
             "buffer-xor": "^2.0.1",
@@ -75436,6 +77648,8 @@
             },
             "buffer-xor": {
               "version": "2.0.2",
+              "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-2.0.2.tgz",
+              "integrity": "sha512-eHslX0bin3GB+Lx2p7lEYRShRewuNZL3fUl4qlVJGGiwoPGftmt8JQgk2Y9Ji5/01TnVDo33E5b5O3vUB1HdqQ==",
               "requires": {
                 "safe-buffer": "^5.1.1"
               }
@@ -75462,15 +77676,21 @@
           "dependencies": {
             "js-sha3": {
               "version": "0.8.0",
+              "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+              "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
               "optional": true
             }
           }
         },
         "ethereum-common": {
-          "version": "0.0.18"
+          "version": "0.0.18",
+          "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.18.tgz",
+          "integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8="
         },
         "ethereum-cryptography": {
           "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
+          "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
           "requires": {
             "@types/pbkdf2": "^3.0.0",
             "@types/secp256k1": "^4.0.1",
@@ -75491,6 +77711,8 @@
         },
         "ethereumjs-abi": {
           "version": "0.6.8",
+          "resolved": "https://registry.npmjs.org/ethereumjs-abi/-/ethereumjs-abi-0.6.8.tgz",
+          "integrity": "sha512-Tx0r/iXI6r+lRsdvkFDlut0N08jWMnKRZ6Gkq+Nmw75lZe4e6o3EkSnkaBP5NF6+m5PTGAr9JP43N3LyeoglsA==",
           "requires": {
             "bn.js": "^4.11.8",
             "ethereumjs-util": "^6.0.0"
@@ -75498,6 +77720,8 @@
         },
         "ethereumjs-account": {
           "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-account/-/ethereumjs-account-3.0.0.tgz",
+          "integrity": "sha512-WP6BdscjiiPkQfF9PVfMcwx/rDvfZTjFKY0Uwc09zSQr9JfIVH87dYIJu0gNhBhpmovV4yq295fdllS925fnBA==",
           "requires": {
             "ethereumjs-util": "^6.0.0",
             "rlp": "^2.2.1",
@@ -75506,6 +77730,8 @@
         },
         "ethereumjs-block": {
           "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-2.2.2.tgz",
+          "integrity": "sha512-2p49ifhek3h2zeg/+da6XpdFR3GlqY3BIEiqxGF8j9aSRIgkb7M1Ky+yULBKJOu8PAZxfhsYA+HxUk2aCQp3vg==",
           "requires": {
             "async": "^2.0.1",
             "ethereumjs-common": "^1.5.0",
@@ -75516,18 +77742,24 @@
           "dependencies": {
             "abstract-leveldown": {
               "version": "2.6.3",
+              "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
+              "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
               "requires": {
                 "xtend": "~4.0.0"
               }
             },
             "deferred-leveldown": {
               "version": "1.2.2",
+              "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz",
+              "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
               "requires": {
                 "abstract-leveldown": "~2.6.0"
               }
             },
             "ethereumjs-util": {
               "version": "5.2.1",
+              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+              "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
               "requires": {
                 "bn.js": "^4.11.0",
                 "create-hash": "^1.1.2",
@@ -75539,19 +77771,27 @@
               }
             },
             "isarray": {
-              "version": "0.0.1"
+              "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
             },
             "level-codec": {
-              "version": "7.0.1"
+              "version": "7.0.1",
+              "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-7.0.1.tgz",
+              "integrity": "sha512-Ua/R9B9r3RasXdRmOtd+t9TCOEIIlts+TN/7XTT2unhDaL6sJn83S3rUyljbr6lVtw49N3/yA0HHjpV6Kzb2aQ=="
             },
             "level-errors": {
               "version": "1.0.5",
+              "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.5.tgz",
+              "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
               "requires": {
                 "errno": "~0.1.1"
               }
             },
             "level-iterator-stream": {
               "version": "1.3.1",
+              "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
+              "integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
               "requires": {
                 "inherits": "^2.0.1",
                 "level-errors": "^1.0.3",
@@ -75561,6 +77801,8 @@
               "dependencies": {
                 "readable-stream": {
                   "version": "1.1.14",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+                  "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
                   "requires": {
                     "core-util-is": "~1.0.0",
                     "inherits": "~2.0.1",
@@ -75572,6 +77814,8 @@
             },
             "level-ws": {
               "version": "0.0.0",
+              "resolved": "https://registry.npmjs.org/level-ws/-/level-ws-0.0.0.tgz",
+              "integrity": "sha1-Ny5RIXeSSgBCSwtDrvK7QkltIos=",
               "requires": {
                 "readable-stream": "~1.0.15",
                 "xtend": "~2.1.1"
@@ -75579,6 +77823,8 @@
               "dependencies": {
                 "readable-stream": {
                   "version": "1.0.34",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                  "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                   "requires": {
                     "core-util-is": "~1.0.0",
                     "inherits": "~2.0.1",
@@ -75588,6 +77834,8 @@
                 },
                 "xtend": {
                   "version": "2.1.2",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+                  "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
                   "requires": {
                     "object-keys": "~0.4.0"
                   }
@@ -75596,6 +77844,8 @@
             },
             "levelup": {
               "version": "1.3.9",
+              "resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.9.tgz",
+              "integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
               "requires": {
                 "deferred-leveldown": "~1.2.1",
                 "level-codec": "~7.0.0",
@@ -75607,10 +77857,14 @@
               }
             },
             "ltgt": {
-              "version": "2.2.1"
+              "version": "2.2.1",
+              "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
+              "integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU="
             },
             "memdown": {
               "version": "1.4.1",
+              "resolved": "https://registry.npmjs.org/memdown/-/memdown-1.4.1.tgz",
+              "integrity": "sha1-tOThkhdGZP+65BNhqlAPMRnv4hU=",
               "requires": {
                 "abstract-leveldown": "~2.7.1",
                 "functional-red-black-tree": "^1.0.1",
@@ -75622,6 +77876,8 @@
               "dependencies": {
                 "abstract-leveldown": {
                   "version": "2.7.2",
+                  "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
+                  "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
                   "requires": {
                     "xtend": "~4.0.0"
                   }
@@ -75630,6 +77886,8 @@
             },
             "merkle-patricia-tree": {
               "version": "2.3.2",
+              "resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-2.3.2.tgz",
+              "integrity": "sha512-81PW5m8oz/pz3GvsAwbauj7Y00rqm81Tzad77tHBwU7pIAtN+TJnMSOJhxBKflSVYhptMMb9RskhqHqrSm1V+g==",
               "requires": {
                 "async": "^1.4.2",
                 "ethereumjs-util": "^5.0.0",
@@ -75642,26 +77900,38 @@
               },
               "dependencies": {
                 "async": {
-                  "version": "1.5.2"
+                  "version": "1.5.2",
+                  "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+                  "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
                 }
               }
             },
             "object-keys": {
-              "version": "0.4.0"
+              "version": "0.4.0",
+              "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+              "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY="
             },
             "safe-buffer": {
-              "version": "5.1.2"
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
             },
             "semver": {
-              "version": "5.4.1"
+              "version": "5.4.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+              "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
             },
             "string_decoder": {
-              "version": "0.10.31"
+              "version": "0.10.31",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
             }
           }
         },
         "ethereumjs-blockchain": {
           "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/ethereumjs-blockchain/-/ethereumjs-blockchain-4.0.4.tgz",
+          "integrity": "sha512-zCxaRMUOzzjvX78DTGiKjA+4h2/sF0OYL1QuPux0DHpyq8XiNoF5GYHtb++GUxVlMsMfZV7AVyzbtgcRdIcEPQ==",
           "requires": {
             "async": "^2.6.1",
             "ethashjs": "~0.0.7",
@@ -75676,10 +77946,14 @@
           }
         },
         "ethereumjs-common": {
-          "version": "1.5.0"
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-common/-/ethereumjs-common-1.5.0.tgz",
+          "integrity": "sha512-SZOjgK1356hIY7MRj3/ma5qtfr/4B5BL+G4rP/XSMYr2z1H5el4RX5GReYCKmQmYI/nSBmRnwrZ17IfHuG0viQ=="
         },
         "ethereumjs-tx": {
           "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-2.1.2.tgz",
+          "integrity": "sha512-zZEK1onCeiORb0wyCXUvg94Ve5It/K6GD1K+26KfFKodiBiS6d9lfCXlUKGBBdQ+bv7Day+JK0tj1K+BeNFRAw==",
           "requires": {
             "ethereumjs-common": "^1.5.0",
             "ethereumjs-util": "^6.0.0"
@@ -75687,6 +77961,8 @@
         },
         "ethereumjs-util": {
           "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
+          "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
           "requires": {
             "@types/bn.js": "^4.11.3",
             "bn.js": "^4.11.0",
@@ -75699,6 +77975,8 @@
         },
         "ethereumjs-vm": {
           "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-4.2.0.tgz",
+          "integrity": "sha512-X6qqZbsY33p5FTuZqCnQ4+lo957iUJMM6Mpa6bL4UW0dxM6WmDSHuI4j/zOp1E2TDKImBGCJA9QPfc08PaNubA==",
           "requires": {
             "async": "^2.1.2",
             "async-eventemitter": "^0.2.2",
@@ -75719,30 +77997,42 @@
           "dependencies": {
             "abstract-leveldown": {
               "version": "2.6.3",
+              "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
+              "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
               "requires": {
                 "xtend": "~4.0.0"
               }
             },
             "deferred-leveldown": {
               "version": "1.2.2",
+              "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz",
+              "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
               "requires": {
                 "abstract-leveldown": "~2.6.0"
               }
             },
             "isarray": {
-              "version": "0.0.1"
+              "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
             },
             "level-codec": {
-              "version": "7.0.1"
+              "version": "7.0.1",
+              "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-7.0.1.tgz",
+              "integrity": "sha512-Ua/R9B9r3RasXdRmOtd+t9TCOEIIlts+TN/7XTT2unhDaL6sJn83S3rUyljbr6lVtw49N3/yA0HHjpV6Kzb2aQ=="
             },
             "level-errors": {
               "version": "1.0.5",
+              "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.5.tgz",
+              "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
               "requires": {
                 "errno": "~0.1.1"
               }
             },
             "level-iterator-stream": {
               "version": "1.3.1",
+              "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
+              "integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
               "requires": {
                 "inherits": "^2.0.1",
                 "level-errors": "^1.0.3",
@@ -75752,6 +78042,8 @@
               "dependencies": {
                 "readable-stream": {
                   "version": "1.1.14",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+                  "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
                   "requires": {
                     "core-util-is": "~1.0.0",
                     "inherits": "~2.0.1",
@@ -75763,6 +78055,8 @@
             },
             "level-ws": {
               "version": "0.0.0",
+              "resolved": "https://registry.npmjs.org/level-ws/-/level-ws-0.0.0.tgz",
+              "integrity": "sha1-Ny5RIXeSSgBCSwtDrvK7QkltIos=",
               "requires": {
                 "readable-stream": "~1.0.15",
                 "xtend": "~2.1.1"
@@ -75770,6 +78064,8 @@
               "dependencies": {
                 "readable-stream": {
                   "version": "1.0.34",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                  "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                   "requires": {
                     "core-util-is": "~1.0.0",
                     "inherits": "~2.0.1",
@@ -75779,6 +78075,8 @@
                 },
                 "xtend": {
                   "version": "2.1.2",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+                  "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
                   "requires": {
                     "object-keys": "~0.4.0"
                   }
@@ -75787,6 +78085,8 @@
             },
             "levelup": {
               "version": "1.3.9",
+              "resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.9.tgz",
+              "integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
               "requires": {
                 "deferred-leveldown": "~1.2.1",
                 "level-codec": "~7.0.0",
@@ -75798,10 +78098,14 @@
               }
             },
             "ltgt": {
-              "version": "2.2.1"
+              "version": "2.2.1",
+              "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
+              "integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU="
             },
             "memdown": {
               "version": "1.4.1",
+              "resolved": "https://registry.npmjs.org/memdown/-/memdown-1.4.1.tgz",
+              "integrity": "sha1-tOThkhdGZP+65BNhqlAPMRnv4hU=",
               "requires": {
                 "abstract-leveldown": "~2.7.1",
                 "functional-red-black-tree": "^1.0.1",
@@ -75813,6 +78117,8 @@
               "dependencies": {
                 "abstract-leveldown": {
                   "version": "2.7.2",
+                  "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
+                  "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
                   "requires": {
                     "xtend": "~4.0.0"
                   }
@@ -75821,6 +78127,8 @@
             },
             "merkle-patricia-tree": {
               "version": "2.3.2",
+              "resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-2.3.2.tgz",
+              "integrity": "sha512-81PW5m8oz/pz3GvsAwbauj7Y00rqm81Tzad77tHBwU7pIAtN+TJnMSOJhxBKflSVYhptMMb9RskhqHqrSm1V+g==",
               "requires": {
                 "async": "^1.4.2",
                 "ethereumjs-util": "^5.0.0",
@@ -75833,10 +78141,14 @@
               },
               "dependencies": {
                 "async": {
-                  "version": "1.5.2"
+                  "version": "1.5.2",
+                  "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+                  "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
                 },
                 "ethereumjs-util": {
                   "version": "5.2.1",
+                  "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+                  "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
                   "requires": {
                     "bn.js": "^4.11.0",
                     "create-hash": "^1.1.2",
@@ -75850,21 +78162,31 @@
               }
             },
             "object-keys": {
-              "version": "0.4.0"
+              "version": "0.4.0",
+              "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+              "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY="
             },
             "safe-buffer": {
-              "version": "5.1.2"
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
             },
             "semver": {
-              "version": "5.4.1"
+              "version": "5.4.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+              "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
             },
             "string_decoder": {
-              "version": "0.10.31"
+              "version": "0.10.31",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
             }
           }
         },
         "ethereumjs-wallet": {
           "version": "0.6.5",
+          "resolved": "https://registry.npmjs.org/ethereumjs-wallet/-/ethereumjs-wallet-0.6.5.tgz",
+          "integrity": "sha512-MDwjwB9VQVnpp/Dc1XzA6J1a3wgHQ4hSvA1uWNatdpOrtCbPVuQSKSyRnjLvS0a+KKMw2pvQ9Ybqpb3+eW8oNA==",
           "optional": true,
           "requires": {
             "aes-js": "^3.1.1",
@@ -75880,6 +78202,8 @@
         },
         "ethjs-unit": {
           "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/ethjs-unit/-/ethjs-unit-0.1.6.tgz",
+          "integrity": "sha1-xmWSHkduh7ziqdWIpv4EBbLEFpk=",
           "optional": true,
           "requires": {
             "bn.js": "4.11.6",
@@ -75888,12 +78212,16 @@
           "dependencies": {
             "bn.js": {
               "version": "4.11.6",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+              "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
               "optional": true
             }
           }
         },
         "ethjs-util": {
           "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.6.tgz",
+          "integrity": "sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==",
           "requires": {
             "is-hex-prefixed": "1.0.0",
             "strip-hex-prefix": "1.0.0"
@@ -75901,6 +78229,8 @@
         },
         "eventemitter3": {
           "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
+          "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ==",
           "optional": true
         },
         "events": {
@@ -75908,6 +78238,8 @@
         },
         "evp_bytestokey": {
           "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+          "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
           "requires": {
             "md5.js": "^1.3.4",
             "safe-buffer": "^5.1.1"
@@ -75915,6 +78247,8 @@
         },
         "expand-brackets": {
           "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+          "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "requires": {
             "debug": "^2.3.3",
             "define-property": "^0.2.5",
@@ -75927,30 +78261,40 @@
           "dependencies": {
             "debug": {
               "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
               "requires": {
                 "ms": "2.0.0"
               }
             },
             "define-property": {
               "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "requires": {
                 "is-descriptor": "^0.1.0"
               }
             },
             "extend-shallow": {
               "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
                 "is-extendable": "^0.1.0"
               }
             },
             "is-accessor-descriptor": {
               "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+              "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
               "requires": {
                 "kind-of": "^3.0.2"
               },
               "dependencies": {
                 "kind-of": {
                   "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "requires": {
                     "is-buffer": "^1.1.5"
                   }
@@ -75958,16 +78302,22 @@
               }
             },
             "is-buffer": {
-              "version": "1.1.6"
+              "version": "1.1.6",
+              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+              "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
             },
             "is-data-descriptor": {
               "version": "0.1.4",
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+              "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
               "requires": {
                 "kind-of": "^3.0.2"
               },
               "dependencies": {
                 "kind-of": {
                   "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "requires": {
                     "is-buffer": "^1.1.5"
                   }
@@ -75976,6 +78326,8 @@
             },
             "is-descriptor": {
               "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "requires": {
                 "is-accessor-descriptor": "^0.1.6",
                 "is-data-descriptor": "^0.1.4",
@@ -75983,18 +78335,26 @@
               }
             },
             "is-extendable": {
-              "version": "0.1.1"
+              "version": "0.1.1",
+              "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+              "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
             },
             "kind-of": {
-              "version": "5.1.0"
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
             },
             "ms": {
-              "version": "2.0.0"
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
             }
           }
         },
         "express": {
           "version": "4.17.1",
+          "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
+          "integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
           "optional": true,
           "requires": {
             "accepts": "~1.3.7",
@@ -76031,6 +78391,8 @@
           "dependencies": {
             "debug": {
               "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
               "optional": true,
               "requires": {
                 "ms": "2.0.0"
@@ -76038,20 +78400,28 @@
             },
             "ms": {
               "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
               "optional": true
             },
             "qs": {
               "version": "6.7.0",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+              "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
               "optional": true
             },
             "safe-buffer": {
               "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
               "optional": true
             }
           }
         },
         "ext": {
           "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
+          "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
           "requires": {
             "type": "^2.0.0"
           },
@@ -76062,10 +78432,14 @@
           }
         },
         "extend": {
-          "version": "3.0.2"
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+          "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
         },
         "extend-shallow": {
           "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+          "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
           "requires": {
             "assign-symbols": "^1.0.0",
             "is-extendable": "^1.0.1"
@@ -76073,6 +78447,8 @@
         },
         "extglob": {
           "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+          "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "requires": {
             "array-unique": "^0.3.2",
             "define-property": "^1.0.0",
@@ -76086,47 +78462,67 @@
           "dependencies": {
             "define-property": {
               "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "requires": {
                 "is-descriptor": "^1.0.0"
               }
             },
             "extend-shallow": {
               "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
                 "is-extendable": "^0.1.0"
               }
             },
             "is-extendable": {
-              "version": "0.1.1"
+              "version": "0.1.1",
+              "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+              "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
             }
           }
         },
         "extsprintf": {
-          "version": "1.3.0"
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+          "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
         },
         "fake-merkle-patricia-tree": {
           "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/fake-merkle-patricia-tree/-/fake-merkle-patricia-tree-1.0.1.tgz",
+          "integrity": "sha1-S4w6z7Ugr635hgsfFM2M40As3dM=",
           "requires": {
             "checkpoint-store": "^1.1.0"
           }
         },
         "fast-deep-equal": {
-          "version": "3.1.3"
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
         },
         "fast-json-stable-stringify": {
-          "version": "2.1.0"
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+          "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
         },
         "fetch-ponyfill": {
           "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/fetch-ponyfill/-/fetch-ponyfill-4.1.0.tgz",
+          "integrity": "sha1-rjzl9zLGReq4fkroeTQUcJsjmJM=",
           "requires": {
             "node-fetch": "~1.7.1"
           },
           "dependencies": {
             "is-stream": {
-              "version": "1.1.0"
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+              "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
             },
             "node-fetch": {
               "version": "1.7.3",
+              "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+              "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
               "requires": {
                 "encoding": "^0.1.11",
                 "is-stream": "^1.0.1"
@@ -76136,6 +78532,8 @@
         },
         "finalhandler": {
           "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+          "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
           "optional": true,
           "requires": {
             "debug": "2.6.9",
@@ -76149,6 +78547,8 @@
           "dependencies": {
             "debug": {
               "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
               "optional": true,
               "requires": {
                 "ms": "2.0.0"
@@ -76156,12 +78556,16 @@
             },
             "ms": {
               "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
               "optional": true
             }
           }
         },
         "find-yarn-workspace-root": {
           "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-1.2.1.tgz",
+          "integrity": "sha512-dVtfb0WuQG+8Ag2uWkbG79hOUzEsRrhBzgfn86g2sJPkzmcpGdghbNTfUKGTxymFrY/tLIodDzLoW9nOJ4FY8Q==",
           "requires": {
             "fs-extra": "^4.0.3",
             "micromatch": "^3.1.4"
@@ -76169,6 +78573,8 @@
           "dependencies": {
             "braces": {
               "version": "2.3.2",
+              "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+              "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
               "requires": {
                 "arr-flatten": "^1.1.0",
                 "array-unique": "^0.3.2",
@@ -76184,6 +78590,8 @@
               "dependencies": {
                 "extend-shallow": {
                   "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                  "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                   "requires": {
                     "is-extendable": "^0.1.0"
                   }
@@ -76192,6 +78600,8 @@
             },
             "fill-range": {
               "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+              "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
               "requires": {
                 "extend-shallow": "^2.0.1",
                 "is-number": "^3.0.0",
@@ -76201,6 +78611,8 @@
               "dependencies": {
                 "extend-shallow": {
                   "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                  "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                   "requires": {
                     "is-extendable": "^0.1.0"
                   }
@@ -76209,6 +78621,8 @@
             },
             "fs-extra": {
               "version": "4.0.3",
+              "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+              "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
               "requires": {
                 "graceful-fs": "^4.1.2",
                 "jsonfile": "^4.0.0",
@@ -76216,19 +78630,27 @@
               }
             },
             "is-buffer": {
-              "version": "1.1.6"
+              "version": "1.1.6",
+              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+              "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
             },
             "is-extendable": {
-              "version": "0.1.1"
+              "version": "0.1.1",
+              "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+              "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
             },
             "is-number": {
               "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+              "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
               "requires": {
                 "kind-of": "^3.0.2"
               },
               "dependencies": {
                 "kind-of": {
                   "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "requires": {
                     "is-buffer": "^1.1.5"
                   }
@@ -76237,6 +78659,8 @@
             },
             "micromatch": {
               "version": "3.1.10",
+              "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+              "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
               "requires": {
                 "arr-diff": "^4.0.0",
                 "array-unique": "^0.3.2",
@@ -76255,6 +78679,8 @@
             },
             "to-regex-range": {
               "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+              "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
               "requires": {
                 "is-number": "^3.0.0",
                 "repeat-string": "^1.6.1"
@@ -76263,22 +78689,32 @@
           }
         },
         "flow-stoplight": {
-          "version": "1.0.0"
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/flow-stoplight/-/flow-stoplight-1.0.0.tgz",
+          "integrity": "sha1-SiksW8/4s5+mzAyxqFPYbyfu/3s="
         },
         "for-each": {
           "version": "0.3.3",
+          "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+          "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
           "requires": {
             "is-callable": "^1.1.3"
           }
         },
         "for-in": {
-          "version": "1.0.2"
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+          "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
         },
         "forever-agent": {
-          "version": "0.6.1"
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+          "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
         },
         "form-data": {
           "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+          "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
           "requires": {
             "asynckit": "^0.4.0",
             "combined-stream": "^1.0.6",
@@ -76291,16 +78727,22 @@
         },
         "fragment-cache": {
           "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+          "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
           "requires": {
             "map-cache": "^0.2.2"
           }
         },
         "fresh": {
           "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+          "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
           "optional": true
         },
         "fs-extra": {
           "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
           "requires": {
             "graceful-fs": "^4.1.2",
             "jsonfile": "^4.0.0",
@@ -76308,13 +78750,19 @@
           }
         },
         "fs.realpath": {
-          "version": "1.0.0"
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
         },
         "function-bind": {
-          "version": "1.1.1"
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+          "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
         },
         "functional-red-black-tree": {
-          "version": "1.0.1"
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+          "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
         },
         "get-intrinsic": {
           "version": "1.0.2",
@@ -76326,16 +78774,22 @@
         },
         "get-stream": {
           "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
           "optional": true,
           "requires": {
             "pump": "^3.0.0"
           }
         },
         "get-value": {
-          "version": "2.0.6"
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+          "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
         },
         "getpass": {
           "version": "0.1.7",
+          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+          "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
           "requires": {
             "assert-plus": "^1.0.0"
           }
@@ -76353,6 +78807,8 @@
         },
         "global": {
           "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
+          "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
           "requires": {
             "min-document": "^2.19.0",
             "process": "^0.11.10"
@@ -76360,6 +78816,8 @@
         },
         "got": {
           "version": "9.6.0",
+          "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
+          "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
           "optional": true,
           "requires": {
             "@sindresorhus/is": "^0.14.0",
@@ -76377,6 +78835,8 @@
           "dependencies": {
             "get-stream": {
               "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+              "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
               "optional": true,
               "requires": {
                 "pump": "^3.0.0"
@@ -76388,10 +78848,14 @@
           "version": "4.2.4"
         },
         "har-schema": {
-          "version": "2.0.0"
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+          "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
         },
         "har-validator": {
           "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+          "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
           "requires": {
             "ajv": "^6.12.3",
             "har-schema": "^2.0.0"
@@ -76399,26 +78863,36 @@
         },
         "has": {
           "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+          "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
           "requires": {
             "function-bind": "^1.1.1"
           }
         },
         "has-ansi": {
           "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
           "requires": {
             "ansi-regex": "^2.0.0"
           },
           "dependencies": {
             "ansi-regex": {
-              "version": "2.1.1"
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
             }
           }
         },
         "has-flag": {
-          "version": "3.0.0"
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
         },
         "has-symbol-support-x": {
           "version": "1.4.2",
+          "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
+          "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw==",
           "optional": true
         },
         "has-symbols": {
@@ -76426,6 +78900,8 @@
         },
         "has-to-string-tag-x": {
           "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
+          "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
           "optional": true,
           "requires": {
             "has-symbol-support-x": "^1.4.1"
@@ -76433,6 +78909,8 @@
         },
         "has-value": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+          "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
           "requires": {
             "get-value": "^2.0.6",
             "has-values": "^1.0.0",
@@ -76441,22 +78919,30 @@
         },
         "has-values": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+          "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
           "requires": {
             "is-number": "^3.0.0",
             "kind-of": "^4.0.0"
           },
           "dependencies": {
             "is-buffer": {
-              "version": "1.1.6"
+              "version": "1.1.6",
+              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+              "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
             },
             "is-number": {
               "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+              "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
               "requires": {
                 "kind-of": "^3.0.2"
               },
               "dependencies": {
                 "kind-of": {
                   "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "requires": {
                     "is-buffer": "^1.1.5"
                   }
@@ -76465,6 +78951,8 @@
             },
             "kind-of": {
               "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+              "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
               "requires": {
                 "is-buffer": "^1.1.5"
               }
@@ -76473,6 +78961,8 @@
         },
         "hash-base": {
           "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
+          "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
           "requires": {
             "inherits": "^2.0.4",
             "readable-stream": "^3.6.0",
@@ -76481,6 +78971,8 @@
           "dependencies": {
             "readable-stream": {
               "version": "3.6.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+              "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
               "requires": {
                 "inherits": "^2.0.3",
                 "string_decoder": "^1.1.1",
@@ -76491,16 +78983,22 @@
         },
         "hash.js": {
           "version": "1.1.7",
+          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+          "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
           "requires": {
             "inherits": "^2.0.3",
             "minimalistic-assert": "^1.0.1"
           }
         },
         "heap": {
-          "version": "0.2.6"
+          "version": "0.2.6",
+          "resolved": "https://registry.npmjs.org/heap/-/heap-0.2.6.tgz",
+          "integrity": "sha1-CH4fELBGky/IWU3Z5tN4r8nR5aw="
         },
         "hmac-drbg": {
           "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+          "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
           "requires": {
             "hash.js": "^1.0.3",
             "minimalistic-assert": "^1.0.0",
@@ -76509,6 +79007,8 @@
         },
         "home-or-tmp": {
           "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+          "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
           "requires": {
             "os-homedir": "^1.0.0",
             "os-tmpdir": "^1.0.1"
@@ -76516,10 +79016,14 @@
         },
         "http-cache-semantics": {
           "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
+          "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
           "optional": true
         },
         "http-errors": {
           "version": "1.7.2",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+          "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
           "optional": true,
           "requires": {
             "depd": "~1.1.2",
@@ -76531,16 +79035,22 @@
           "dependencies": {
             "inherits": {
               "version": "2.0.3",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
               "optional": true
             }
           }
         },
         "http-https": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/http-https/-/http-https-1.0.0.tgz",
+          "integrity": "sha1-L5CN1fHbQGjAWM1ubUzjkskTOJs=",
           "optional": true
         },
         "http-signature": {
           "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+          "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
           "requires": {
             "assert-plus": "^1.0.0",
             "jsprim": "^1.2.2",
@@ -76549,6 +79059,8 @@
         },
         "iconv-lite": {
           "version": "0.4.24",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
           "optional": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3"
@@ -76556,6 +79068,8 @@
         },
         "idna-uts46-hx": {
           "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/idna-uts46-hx/-/idna-uts46-hx-2.3.1.tgz",
+          "integrity": "sha512-PWoF9Keq6laYdIRwwCdhTPl60xRqAloYNMQLiyUnG42VjT53oW07BXIRM+NK7eQjzXjAk2gUvX9caRxlnF9TAA==",
           "optional": true,
           "requires": {
             "punycode": "2.1.0"
@@ -76563,38 +79077,54 @@
           "dependencies": {
             "punycode": {
               "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+              "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=",
               "optional": true
             }
           }
         },
         "ieee754": {
-          "version": "1.2.1"
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+          "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
         },
         "immediate": {
-          "version": "3.2.3"
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
+          "integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw="
         },
         "inflight": {
           "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "requires": {
             "once": "^1.3.0",
             "wrappy": "1"
           }
         },
         "inherits": {
-          "version": "2.0.4"
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         },
         "invariant": {
           "version": "2.2.4",
+          "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+          "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
           "requires": {
             "loose-envify": "^1.0.0"
           }
         },
         "ipaddr.js": {
           "version": "1.9.1",
+          "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+          "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
           "optional": true
         },
         "is-accessor-descriptor": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -76610,12 +79140,16 @@
         },
         "is-ci": {
           "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+          "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
           "requires": {
             "ci-info": "^2.0.0"
           }
         },
         "is-data-descriptor": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -76625,6 +79159,8 @@
         },
         "is-descriptor": {
           "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
             "is-data-descriptor": "^1.0.0",
@@ -76633,35 +79169,51 @@
         },
         "is-extendable": {
           "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "requires": {
             "is-plain-object": "^2.0.4"
           }
         },
         "is-finite": {
-          "version": "1.1.0"
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
+          "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w=="
         },
         "is-fn": {
-          "version": "1.0.0"
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fn/-/is-fn-1.0.0.tgz",
+          "integrity": "sha1-lUPV3nvPWwiiLsiiC65uKG1RDYw="
         },
         "is-function": {
-          "version": "1.0.2"
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz",
+          "integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ=="
         },
         "is-hex-prefixed": {
-          "version": "1.0.0"
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
+          "integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ="
         },
         "is-negative-zero": {
           "version": "2.0.1"
         },
         "is-object": {
           "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.2.tgz",
+          "integrity": "sha512-2rRIahhZr2UWb45fIOuvZGpFtz0TyOZLf32KxBbSoUCeZR495zCKlWUKKUByk3geS2eAs7ZAABt0Y/Rx0GiQGA==",
           "optional": true
         },
         "is-plain-obj": {
           "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+          "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
           "optional": true
         },
         "is-plain-object": {
           "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+          "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
           "requires": {
             "isobject": "^3.0.1"
           }
@@ -76674,6 +79226,8 @@
         },
         "is-retry-allowed": {
           "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
+          "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
           "optional": true
         },
         "is-symbol": {
@@ -76683,25 +79237,39 @@
           }
         },
         "is-typedarray": {
-          "version": "1.0.0"
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
         },
         "is-windows": {
-          "version": "1.0.2"
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+          "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
         },
         "isarray": {
-          "version": "1.0.0"
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "isexe": {
-          "version": "2.0.0"
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+          "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
         },
         "isobject": {
-          "version": "3.0.1"
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
         },
         "isstream": {
-          "version": "0.1.2"
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+          "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
         },
         "isurl": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
+          "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
           "optional": true,
           "requires": {
             "has-to-string-tag-x": "^1.2.0",
@@ -76710,20 +79278,28 @@
         },
         "js-sha3": {
           "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
+          "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=",
           "optional": true
         },
         "js-tokens": {
           "version": "4.0.0"
         },
         "jsbn": {
-          "version": "0.1.1"
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
         },
         "json-buffer": {
           "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
+          "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
           "optional": true
         },
         "json-rpc-engine": {
           "version": "3.8.0",
+          "resolved": "https://registry.npmjs.org/json-rpc-engine/-/json-rpc-engine-3.8.0.tgz",
+          "integrity": "sha512-6QNcvm2gFuuK4TKU1uwfH0Qd/cOSb9c1lls0gbnIhciktIUQJwz6NQNAW4B1KiGPenv7IKu97V222Yo1bNhGuA==",
           "requires": {
             "async": "^2.0.1",
             "babel-preset-env": "^1.7.0",
@@ -76735,39 +79311,57 @@
         },
         "json-rpc-error": {
           "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/json-rpc-error/-/json-rpc-error-2.0.0.tgz",
+          "integrity": "sha1-p6+cICg4tekFxyUOVH8a/3cligI=",
           "requires": {
             "inherits": "^2.0.1"
           }
         },
         "json-rpc-random-id": {
-          "version": "1.0.1"
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/json-rpc-random-id/-/json-rpc-random-id-1.0.1.tgz",
+          "integrity": "sha1-uknZat7RRE27jaPSA3SKy7zeyMg="
         },
         "json-schema": {
-          "version": "0.2.3"
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
         },
         "json-schema-traverse": {
-          "version": "0.4.1"
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
         },
         "json-stable-stringify": {
           "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+          "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
           "requires": {
             "jsonify": "~0.0.0"
           }
         },
         "json-stringify-safe": {
-          "version": "5.0.1"
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
         },
         "jsonfile": {
           "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
           "requires": {
             "graceful-fs": "^4.1.6"
           }
         },
         "jsonify": {
-          "version": "0.0.0"
+          "version": "0.0.0",
+          "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+          "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
         },
         "jsprim": {
           "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+          "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
           "requires": {
             "assert-plus": "1.0.0",
             "extsprintf": "1.3.0",
@@ -76777,6 +79371,8 @@
         },
         "keccak": {
           "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.1.tgz",
+          "integrity": "sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==",
           "bundled": true,
           "requires": {
             "node-addon-api": "^2.0.0",
@@ -76785,34 +79381,46 @@
         },
         "keyv": {
           "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
+          "integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
           "optional": true,
           "requires": {
             "json-buffer": "3.0.0"
           }
         },
         "kind-of": {
-          "version": "6.0.3"
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
         },
         "klaw-sync": {
           "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+          "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
           "requires": {
             "graceful-fs": "^4.1.11"
           }
         },
         "level-codec": {
           "version": "9.0.2",
+          "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.2.tgz",
+          "integrity": "sha512-UyIwNb1lJBChJnGfjmO0OR+ezh2iVu1Kas3nvBS/BzGnx79dv6g7unpKIDNPMhfdTEGoc7mC8uAu51XEtX+FHQ==",
           "requires": {
             "buffer": "^5.6.0"
           }
         },
         "level-errors": {
           "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-2.0.1.tgz",
+          "integrity": "sha512-UVprBJXite4gPS+3VznfgDSU8PTRuVX0NXwoWW50KLxd2yw4Y1t2JUR5In1itQnudZqRMT9DlAM3Q//9NCjCFw==",
           "requires": {
             "errno": "~0.1.1"
           }
         },
         "level-iterator-stream": {
           "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-2.0.3.tgz",
+          "integrity": "sha512-I6Heg70nfF+e5Y3/qfthJFexhRw/Gi3bIymCoXAlijZdAcLaPuWSJs3KXyTYf23ID6g0o2QF62Yh+grOXY3Rig==",
           "requires": {
             "inherits": "^2.0.1",
             "readable-stream": "^2.0.5",
@@ -76821,6 +79429,8 @@
         },
         "level-mem": {
           "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/level-mem/-/level-mem-3.0.1.tgz",
+          "integrity": "sha512-LbtfK9+3Ug1UmvvhR2DqLqXiPW1OJ5jEh0a3m9ZgAipiwpSxGj/qaVVy54RG5vAQN1nCuXqjvprCuKSCxcJHBg==",
           "requires": {
             "level-packager": "~4.0.0",
             "memdown": "~3.0.0"
@@ -76828,15 +79438,21 @@
           "dependencies": {
             "abstract-leveldown": {
               "version": "5.0.0",
+              "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-5.0.0.tgz",
+              "integrity": "sha512-5mU5P1gXtsMIXg65/rsYGsi93+MlogXZ9FA8JnwKurHQg64bfXwGYVdVdijNTVNOlAsuIiOwHdvFFD5JqCJQ7A==",
               "requires": {
                 "xtend": "~4.0.0"
               }
             },
             "ltgt": {
-              "version": "2.2.1"
+              "version": "2.2.1",
+              "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
+              "integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU="
             },
             "memdown": {
               "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/memdown/-/memdown-3.0.0.tgz",
+              "integrity": "sha512-tbV02LfZMWLcHcq4tw++NuqMO+FZX8tNJEiD2aNRm48ZZusVg5N8NART+dmBkepJVye986oixErf7jfXboMGMA==",
               "requires": {
                 "abstract-leveldown": "~5.0.0",
                 "functional-red-black-tree": "~1.0.1",
@@ -76847,12 +79463,16 @@
               }
             },
             "safe-buffer": {
-              "version": "5.1.2"
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
             }
           }
         },
         "level-packager": {
           "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-4.0.1.tgz",
+          "integrity": "sha512-svCRKfYLn9/4CoFfi+d8krOtrp6RoX8+xm0Na5cgXMqSyRru0AnDYdLl+YI8u1FyS6gGZ94ILLZDE5dh2but3Q==",
           "requires": {
             "encoding-down": "~5.0.0",
             "levelup": "^3.0.0"
@@ -76860,12 +79480,16 @@
         },
         "level-post": {
           "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/level-post/-/level-post-1.0.7.tgz",
+          "integrity": "sha512-PWYqG4Q00asOrLhX7BejSajByB4EmG2GaKHfj3h5UmmZ2duciXLPGYWIjBzLECFWUGOZWlm5B20h/n3Gs3HKew==",
           "requires": {
             "ltgt": "^2.1.2"
           }
         },
         "level-sublevel": {
           "version": "6.6.4",
+          "resolved": "https://registry.npmjs.org/level-sublevel/-/level-sublevel-6.6.4.tgz",
+          "integrity": "sha512-pcCrTUOiO48+Kp6F1+UAzF/OtWqLcQVTVF39HLdZ3RO8XBoXt+XVPKZO1vVr1aUoxHZA9OtD2e1v7G+3S5KFDA==",
           "requires": {
             "bytewise": "~1.1.0",
             "level-codec": "^9.0.0",
@@ -76881,6 +79505,8 @@
         },
         "level-ws": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/level-ws/-/level-ws-1.0.0.tgz",
+          "integrity": "sha512-RXEfCmkd6WWFlArh3X8ONvQPm8jNpfA0s/36M4QzLqrLEIt1iJE9WBHLZ5vZJK6haMjJPJGJCQWfjMNnRcq/9Q==",
           "requires": {
             "inherits": "^2.0.3",
             "readable-stream": "^2.2.8",
@@ -76889,6 +79515,8 @@
         },
         "levelup": {
           "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/levelup/-/levelup-3.1.1.tgz",
+          "integrity": "sha512-9N10xRkUU4dShSRRFTBdNaBxofz+PGaIZO962ckboJZiNmLuhVT6FZ6ZKAsICKfUBO76ySaYU6fJWX/jnj3Lcg==",
           "requires": {
             "deferred-leveldown": "~4.0.0",
             "level-errors": "~2.0.0",
@@ -76898,6 +79526,8 @@
           "dependencies": {
             "level-iterator-stream": {
               "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-3.0.1.tgz",
+              "integrity": "sha512-nEIQvxEED9yRThxvOrq8Aqziy4EGzrxSZK+QzEFAVuJvQ8glfyZ96GB6BoI4sBbLfjMXm2w4vu3Tkcm9obcY0g==",
               "requires": {
                 "inherits": "^2.0.1",
                 "readable-stream": "^2.3.6",
@@ -76907,41 +79537,59 @@
           }
         },
         "lodash": {
-          "version": "4.17.20"
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
         },
         "looper": {
-          "version": "2.0.0"
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/looper/-/looper-2.0.0.tgz",
+          "integrity": "sha1-Zs0Md0rz1P7axTeU90LbVtqPCew="
         },
         "loose-envify": {
           "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+          "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
           "requires": {
             "js-tokens": "^3.0.0 || ^4.0.0"
           }
         },
         "lowercase-keys": {
           "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+          "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
           "optional": true
         },
         "lru-cache": {
           "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
           "requires": {
             "yallist": "^3.0.2"
           }
         },
         "ltgt": {
-          "version": "2.1.3"
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.1.3.tgz",
+          "integrity": "sha1-EIUaBtmWS5cReEQcI8nlJpjuzjQ="
         },
         "map-cache": {
-          "version": "0.2.2"
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+          "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
         },
         "map-visit": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+          "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
           "requires": {
             "object-visit": "^1.0.0"
           }
         },
         "md5.js": {
           "version": "1.3.5",
+          "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+          "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
           "requires": {
             "hash-base": "^3.0.0",
             "inherits": "^2.0.1",
@@ -76950,14 +79598,20 @@
         },
         "media-typer": {
           "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+          "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
           "optional": true
         },
         "merge-descriptors": {
           "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+          "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
           "optional": true
         },
         "merkle-patricia-tree": {
           "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-3.0.0.tgz",
+          "integrity": "sha512-soRaMuNf/ILmw3KWbybaCjhx86EYeBbD8ph0edQCTed0JN/rxDt1EBN52Ajre3VyGo+91f8+/rfPIRQnnGMqmQ==",
           "requires": {
             "async": "^2.6.1",
             "ethereumjs-util": "^5.2.0",
@@ -76970,6 +79624,8 @@
           "dependencies": {
             "ethereumjs-util": {
               "version": "5.2.1",
+              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+              "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
               "requires": {
                 "bn.js": "^4.11.0",
                 "create-hash": "^1.1.2",
@@ -76982,6 +79638,8 @@
             },
             "readable-stream": {
               "version": "3.6.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+              "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
               "requires": {
                 "inherits": "^2.0.3",
                 "string_decoder": "^1.1.1",
@@ -76992,10 +79650,14 @@
         },
         "methods": {
           "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+          "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
           "optional": true
         },
         "miller-rabin": {
           "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
+          "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
           "requires": {
             "bn.js": "^4.0.0",
             "brorand": "^1.0.1"
@@ -77003,6 +79665,8 @@
         },
         "mime": {
           "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+          "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
           "optional": true
         },
         "mime-db": {
@@ -77016,28 +79680,40 @@
         },
         "mimic-response": {
           "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+          "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
           "optional": true
         },
         "min-document": {
           "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+          "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
           "requires": {
             "dom-walk": "^0.1.0"
           }
         },
         "minimalistic-assert": {
-          "version": "1.0.1"
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+          "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
         },
         "minimalistic-crypto-utils": {
-          "version": "1.0.1"
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+          "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
         },
         "minimatch": {
           "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
-          "version": "1.2.5"
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
         },
         "minizlib": {
           "version": "1.3.3",
@@ -77048,6 +79724,8 @@
           "dependencies": {
             "minipass": {
               "version": "2.9.0",
+              "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+              "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
               "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
@@ -77058,6 +79736,8 @@
         },
         "mixin-deep": {
           "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+          "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
           "requires": {
             "for-in": "^1.0.2",
             "is-extendable": "^1.0.1"
@@ -77065,12 +79745,16 @@
         },
         "mkdirp": {
           "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
           "requires": {
             "minimist": "^1.2.5"
           }
         },
         "mkdirp-promise": {
           "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/mkdirp-promise/-/mkdirp-promise-5.0.1.tgz",
+          "integrity": "sha1-6bj2jlUsaKnBcTuEiD96HdA5uKE=",
           "optional": true,
           "requires": {
             "mkdirp": "*"
@@ -77081,10 +79765,14 @@
           "optional": true
         },
         "ms": {
-          "version": "2.1.3"
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         },
         "multibase": {
           "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.6.1.tgz",
+          "integrity": "sha512-pFfAwyTjbbQgNc3G7D48JkJxWtoJoBMaR4xQUOuB8RnCgRqaYmWNFeJTTvrJ2w51bjLq2zTby6Rqj9TQ9elSUw==",
           "optional": true,
           "requires": {
             "base-x": "^3.0.8",
@@ -77093,6 +79781,8 @@
         },
         "multicodec": {
           "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-0.5.7.tgz",
+          "integrity": "sha512-PscoRxm3f+88fAtELwUnZxGDkduE2HD9Q6GHUOywQLjOGT/HAdhjLDYNZ1e7VR0s0TP0EwZ16LNUTFpoBGivOA==",
           "optional": true,
           "requires": {
             "varint": "^5.0.0"
@@ -77100,6 +79790,8 @@
         },
         "multihashes": {
           "version": "0.4.21",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.21.tgz",
+          "integrity": "sha512-uVSvmeCWf36pU2nB4/1kzYZjsXD9vofZKpgudqkceYY5g2aZZXJ5r9lxuzoRLl1OAp28XljXsEJ/X/85ZsKmKw==",
           "optional": true,
           "requires": {
             "buffer": "^5.5.0",
@@ -77109,6 +79801,8 @@
           "dependencies": {
             "multibase": {
               "version": "0.7.0",
+              "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
+              "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
               "optional": true,
               "requires": {
                 "base-x": "^3.0.8",
@@ -77119,10 +79813,14 @@
         },
         "nano-json-stream-parser": {
           "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/nano-json-stream-parser/-/nano-json-stream-parser-0.1.2.tgz",
+          "integrity": "sha1-DMj20OK2IrR5xA1JnEbWS3Vcb18=",
           "optional": true
         },
         "nanomatch": {
           "version": "1.2.13",
+          "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+          "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
           "requires": {
             "arr-diff": "^4.0.0",
             "array-unique": "^0.3.2",
@@ -77139,16 +79837,24 @@
         },
         "negotiator": {
           "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
+          "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
           "optional": true
         },
         "next-tick": {
-          "version": "1.0.0"
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+          "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
         },
         "nice-try": {
-          "version": "1.0.5"
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+          "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
         },
         "node-addon-api": {
           "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
+          "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==",
           "bundled": true
         },
         "node-fetch": {
@@ -77156,6 +79862,8 @@
         },
         "node-gyp-build": {
           "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
+          "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==",
           "bundled": true
         },
         "normalize-url": {
@@ -77164,6 +79872,8 @@
         },
         "number-to-bn": {
           "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
+          "integrity": "sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=",
           "optional": true,
           "requires": {
             "bn.js": "4.11.6",
@@ -77172,18 +79882,26 @@
           "dependencies": {
             "bn.js": {
               "version": "4.11.6",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+              "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
               "optional": true
             }
           }
         },
         "oauth-sign": {
-          "version": "0.9.0"
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+          "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
         },
         "object-assign": {
-          "version": "4.1.1"
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
         },
         "object-copy": {
           "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+          "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
           "requires": {
             "copy-descriptor": "^0.1.0",
             "define-property": "^0.2.5",
@@ -77192,27 +79910,37 @@
           "dependencies": {
             "define-property": {
               "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "requires": {
                 "is-descriptor": "^0.1.0"
               }
             },
             "is-accessor-descriptor": {
               "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+              "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
               "requires": {
                 "kind-of": "^3.0.2"
               }
             },
             "is-buffer": {
-              "version": "1.1.6"
+              "version": "1.1.6",
+              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+              "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
             },
             "is-data-descriptor": {
               "version": "0.1.4",
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+              "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
               "requires": {
                 "kind-of": "^3.0.2"
               }
             },
             "is-descriptor": {
               "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "requires": {
                 "is-accessor-descriptor": "^0.1.6",
                 "is-data-descriptor": "^0.1.4",
@@ -77220,12 +79948,16 @@
               },
               "dependencies": {
                 "kind-of": {
-                  "version": "5.1.0"
+                  "version": "5.1.0",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                  "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
                 }
               }
             },
             "kind-of": {
               "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
                 "is-buffer": "^1.1.5"
               }
@@ -77243,10 +79975,14 @@
           }
         },
         "object-keys": {
-          "version": "1.1.1"
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
         },
         "object-visit": {
           "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+          "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
           "requires": {
             "isobject": "^3.0.0"
           }
@@ -77270,12 +80006,16 @@
         },
         "object.pick": {
           "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+          "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
           "requires": {
             "isobject": "^3.0.1"
           }
         },
         "oboe": {
           "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/oboe/-/oboe-2.1.4.tgz",
+          "integrity": "sha1-IMiM2wwVNxuwQRklfU/dNLCqSfY=",
           "optional": true,
           "requires": {
             "http-https": "^1.0.0"
@@ -77283,6 +80023,8 @@
         },
         "on-finished": {
           "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+          "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
           "optional": true,
           "requires": {
             "ee-first": "1.1.1"
@@ -77290,22 +80032,32 @@
         },
         "once": {
           "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "requires": {
             "wrappy": "1"
           }
         },
         "os-homedir": {
-          "version": "1.0.2"
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
         },
         "os-tmpdir": {
-          "version": "1.0.2"
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
         },
         "p-cancelable": {
           "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
+          "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
           "optional": true
         },
         "p-timeout": {
           "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
+          "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
           "optional": true,
           "requires": {
             "p-finally": "^1.0.0"
@@ -77313,12 +80065,16 @@
           "dependencies": {
             "p-finally": {
               "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+              "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
               "optional": true
             }
           }
         },
         "parse-asn1": {
           "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.6.tgz",
+          "integrity": "sha512-RnZRo1EPU6JBnra2vGHj0yhp6ebyjBZpmUCLHWiFhxlzvBCCpAuZ7elsBp1PVAbQN0/04VD/19rfzlBSwLstMw==",
           "optional": true,
           "requires": {
             "asn1.js": "^5.2.0",
@@ -77333,13 +80089,19 @@
         },
         "parseurl": {
           "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+          "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
           "optional": true
         },
         "pascalcase": {
-          "version": "0.1.1"
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+          "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
         },
         "patch-package": {
           "version": "6.2.2",
+          "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-6.2.2.tgz",
+          "integrity": "sha512-YqScVYkVcClUY0v8fF0kWOjDYopzIM8e3bj/RU1DPeEF14+dCGm6UeOYm4jvCyxqIEQ5/eJzmbWfDWnUleFNMg==",
           "requires": {
             "@yarnpkg/lockfile": "^1.1.0",
             "chalk": "^2.4.2",
@@ -77357,6 +80119,8 @@
           "dependencies": {
             "cross-spawn": {
               "version": "6.0.5",
+              "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+              "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
               "requires": {
                 "nice-try": "^1.0.4",
                 "path-key": "^2.0.1",
@@ -77366,31 +80130,45 @@
               }
             },
             "path-key": {
-              "version": "2.0.1"
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+              "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
             },
             "semver": {
-              "version": "5.7.1"
+              "version": "5.7.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
             },
             "shebang-command": {
               "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+              "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
               "requires": {
                 "shebang-regex": "^1.0.0"
               }
             },
             "shebang-regex": {
-              "version": "1.0.0"
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+              "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
             },
             "slash": {
-              "version": "2.0.0"
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+              "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A=="
             },
             "tmp": {
               "version": "0.0.33",
+              "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+              "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
               "requires": {
                 "os-tmpdir": "~1.0.2"
               }
             },
             "which": {
               "version": "1.3.1",
+              "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+              "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
               "requires": {
                 "isexe": "^2.0.0"
               }
@@ -77398,13 +80176,17 @@
           }
         },
         "path-is-absolute": {
-          "version": "1.0.1"
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
         },
         "path-parse": {
           "version": "1.0.6"
         },
         "path-to-regexp": {
           "version": "0.1.7",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+          "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
           "optional": true
         },
         "pbkdf2": {
@@ -77418,29 +80200,45 @@
           }
         },
         "performance-now": {
-          "version": "2.1.0"
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+          "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
         },
         "posix-character-classes": {
-          "version": "0.1.1"
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+          "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
         },
         "precond": {
-          "version": "0.2.3"
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
+          "integrity": "sha1-qpWRvKokkj8eD0hJ0kD0fvwQdaw="
         },
         "prepend-http": {
           "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+          "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
           "optional": true
         },
         "private": {
-          "version": "0.1.8"
+          "version": "0.1.8",
+          "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+          "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
         },
         "process": {
-          "version": "0.11.10"
+          "version": "0.11.10",
+          "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+          "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
         },
         "process-nextick-args": {
-          "version": "2.0.1"
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+          "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
         },
         "promise-to-callback": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/promise-to-callback/-/promise-to-callback-1.0.0.tgz",
+          "integrity": "sha1-XSp0kBC/tn2WNZj805YHRqaP7vc=",
           "requires": {
             "is-fn": "^1.0.0",
             "set-immediate-shim": "^1.0.1"
@@ -77455,16 +80253,24 @@
           }
         },
         "prr": {
-          "version": "1.0.1"
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+          "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
         },
         "pseudomap": {
-          "version": "1.0.2"
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+          "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
         },
         "psl": {
-          "version": "1.8.0"
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+          "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
         },
         "public-encrypt": {
           "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
+          "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
           "optional": true,
           "requires": {
             "bn.js": "^4.1.0",
@@ -77476,13 +80282,19 @@
           }
         },
         "pull-cat": {
-          "version": "1.1.11"
+          "version": "1.1.11",
+          "resolved": "https://registry.npmjs.org/pull-cat/-/pull-cat-1.1.11.tgz",
+          "integrity": "sha1-tkLdElXaN2pwa220+pYvX9t0wxs="
         },
         "pull-defer": {
-          "version": "0.2.3"
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/pull-defer/-/pull-defer-0.2.3.tgz",
+          "integrity": "sha512-/An3KE7mVjZCqNhZsr22k1Tx8MACnUnHZZNPSJ0S62td8JtYr/AiRG42Vz7Syu31SoTLUzVIe61jtT/pNdjVYA=="
         },
         "pull-level": {
           "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/pull-level/-/pull-level-2.0.4.tgz",
+          "integrity": "sha512-fW6pljDeUThpq5KXwKbRG3X7Ogk3vc75d5OQU/TvXXui65ykm+Bn+fiktg+MOx2jJ85cd+sheufPL+rw9QSVZg==",
           "requires": {
             "level-post": "^1.0.7",
             "pull-cat": "^1.1.9",
@@ -77495,25 +80307,35 @@
         },
         "pull-live": {
           "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/pull-live/-/pull-live-1.0.1.tgz",
+          "integrity": "sha1-pOzuAeMwFV6RJLu89HYfIbOPUfU=",
           "requires": {
             "pull-cat": "^1.1.9",
             "pull-stream": "^3.4.0"
           }
         },
         "pull-pushable": {
-          "version": "2.2.0"
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/pull-pushable/-/pull-pushable-2.2.0.tgz",
+          "integrity": "sha1-Xy867UethpGfAbEqLpnW8b13ZYE="
         },
         "pull-stream": {
-          "version": "3.6.14"
+          "version": "3.6.14",
+          "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.14.tgz",
+          "integrity": "sha512-KIqdvpqHHaTUA2mCYcLG1ibEbu/LCKoJZsBWyv9lSYtPkJPBq8m3Hxa103xHi6D2thj5YXa0TqK3L3GUkwgnew=="
         },
         "pull-window": {
           "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/pull-window/-/pull-window-2.1.4.tgz",
+          "integrity": "sha1-/DuG/uvRkgx64pdpHiP3BfiFUvA=",
           "requires": {
             "looper": "^2.0.0"
           }
         },
         "pump": {
           "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
           "optional": true,
           "requires": {
             "end-of-stream": "^1.1.0",
@@ -77521,13 +80343,19 @@
           }
         },
         "punycode": {
-          "version": "2.1.1"
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
         },
         "qs": {
-          "version": "6.5.2"
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
         },
         "query-string": {
           "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+          "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
           "optional": true,
           "requires": {
             "decode-uri-component": "^0.2.0",
@@ -77537,12 +80365,16 @@
         },
         "randombytes": {
           "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+          "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
           "requires": {
             "safe-buffer": "^5.1.0"
           }
         },
         "randomfill": {
           "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
+          "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
           "optional": true,
           "requires": {
             "randombytes": "^2.0.5",
@@ -77551,10 +80383,14 @@
         },
         "range-parser": {
           "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+          "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
           "optional": true
         },
         "raw-body": {
           "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
+          "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
           "optional": true,
           "requires": {
             "bytes": "3.1.0",
@@ -77565,6 +80401,8 @@
         },
         "readable-stream": {
           "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -77576,18 +80414,26 @@
           },
           "dependencies": {
             "safe-buffer": {
-              "version": "5.1.2"
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
             }
           }
         },
         "regenerate": {
-          "version": "1.4.2"
+          "version": "1.4.2",
+          "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
+          "integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A=="
         },
         "regenerator-runtime": {
-          "version": "0.11.1"
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
         },
         "regenerator-transform": {
           "version": "0.10.1",
+          "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
+          "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
           "requires": {
             "babel-runtime": "^6.18.0",
             "babel-types": "^6.19.0",
@@ -77596,6 +80442,8 @@
         },
         "regex-not": {
           "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+          "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
           "requires": {
             "extend-shallow": "^3.0.2",
             "safe-regex": "^1.1.0"
@@ -77628,6 +80476,8 @@
         },
         "regexpu-core": {
           "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
+          "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
           "requires": {
             "regenerate": "^1.2.1",
             "regjsgen": "^0.2.0",
@@ -77635,16 +80485,22 @@
           }
         },
         "regjsgen": {
-          "version": "0.2.0"
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+          "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
         },
         "regjsparser": {
           "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+          "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
           "requires": {
             "jsesc": "~0.5.0"
           },
           "dependencies": {
             "jsesc": {
-              "version": "0.5.0"
+              "version": "0.5.0",
+              "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+              "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
             }
           }
         },
@@ -77652,16 +80508,22 @@
           "version": "1.1.3"
         },
         "repeat-string": {
-          "version": "1.6.1"
+          "version": "1.6.1",
+          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+          "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
         },
         "repeating": {
           "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+          "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
           "requires": {
             "is-finite": "^1.0.0"
           }
         },
         "request": {
           "version": "2.88.2",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+          "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
           "requires": {
             "aws-sign2": "~0.7.0",
             "aws4": "^1.8.0",
@@ -77686,10 +80548,14 @@
           }
         },
         "resolve-url": {
-          "version": "0.2.1"
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+          "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
         },
         "responselike": {
           "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
+          "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
           "optional": true,
           "requires": {
             "lowercase-keys": "^1.0.0"
@@ -77697,12 +80563,16 @@
         },
         "resumer": {
           "version": "0.0.0",
+          "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
+          "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
           "requires": {
             "through": "~2.3.4"
           }
         },
         "ret": {
-          "version": "0.1.15"
+          "version": "0.1.15",
+          "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+          "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
         },
         "rimraf": {
           "version": "2.6.3",
@@ -77712,6 +80582,8 @@
         },
         "ripemd160": {
           "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+          "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
           "requires": {
             "hash-base": "^3.0.0",
             "inherits": "^2.0.1"
@@ -77719,36 +80591,52 @@
         },
         "rlp": {
           "version": "2.2.6",
+          "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.6.tgz",
+          "integrity": "sha512-HAfAmL6SDYNWPUOJNrM500x4Thn4PZsEy5pijPh40U9WfNk0z15hUYzO9xVIMAdIHdFtD8CBDHd75Td1g36Mjg==",
           "requires": {
             "bn.js": "^4.11.1"
           }
         },
         "rustbn.js": {
-          "version": "0.2.0"
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/rustbn.js/-/rustbn.js-0.2.0.tgz",
+          "integrity": "sha512-4VlvkRUuCJvr2J6Y0ImW7NvTCriMi7ErOAqWk1y69vAdoNIzCF3yPmgeNzx+RQTLEDFq5sHfscn1MwHxP9hNfA=="
         },
         "safe-buffer": {
-          "version": "5.2.1"
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
         },
         "safe-event-emitter": {
           "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/safe-event-emitter/-/safe-event-emitter-1.0.1.tgz",
+          "integrity": "sha512-e1wFe99A91XYYxoQbcq2ZJUWurxEyP8vfz7A7vuUe1s95q8r5ebraVaA1BukYJcpM6V16ugWoD9vngi8Ccu5fg==",
           "requires": {
             "events": "^3.0.0"
           }
         },
         "safe-regex": {
           "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+          "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
           "requires": {
             "ret": "~0.1.10"
           }
         },
         "safer-buffer": {
-          "version": "2.1.2"
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
         },
         "scrypt-js": {
-          "version": "3.0.1"
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
+          "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
         },
         "scryptsy": {
           "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/scryptsy/-/scryptsy-1.2.1.tgz",
+          "integrity": "sha1-oyJfpLJST4AnAHYeKFW987LZIWM=",
           "optional": true,
           "requires": {
             "pbkdf2": "^3.0.3"
@@ -77756,6 +80644,8 @@
         },
         "secp256k1": {
           "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
+          "integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
           "requires": {
             "elliptic": "^6.5.2",
             "node-addon-api": "^2.0.0",
@@ -77763,13 +80653,19 @@
           }
         },
         "seedrandom": {
-          "version": "3.0.1"
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.1.tgz",
+          "integrity": "sha512-1/02Y/rUeU1CJBAGLebiC5Lbo5FnB22gQbIFFYTLkwvp1xdABZJH1sn4ZT1MzXmPpzv+Rf/Lu2NcsLJiK4rcDg=="
         },
         "semaphore": {
-          "version": "1.1.0"
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/semaphore/-/semaphore-1.1.0.tgz",
+          "integrity": "sha512-O4OZEaNtkMd/K0i6js9SL+gqy0ZCBMgUvlSqHKi4IBdjhe7wB8pwztUk1BbZ1fmrvpwFrPbHzqd2w5pTcJH6LA=="
         },
         "send": {
           "version": "0.17.1",
+          "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
+          "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
           "optional": true,
           "requires": {
             "debug": "2.6.9",
@@ -77789,6 +80685,8 @@
           "dependencies": {
             "debug": {
               "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
               "optional": true,
               "requires": {
                 "ms": "2.0.0"
@@ -77796,18 +80694,24 @@
               "dependencies": {
                 "ms": {
                   "version": "2.0.0",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                  "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
                   "optional": true
                 }
               }
             },
             "ms": {
               "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+              "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
               "optional": true
             }
           }
         },
         "serve-static": {
           "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
+          "integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
           "optional": true,
           "requires": {
             "encodeurl": "~1.0.2",
@@ -77818,6 +80722,8 @@
         },
         "servify": {
           "version": "0.1.12",
+          "resolved": "https://registry.npmjs.org/servify/-/servify-0.1.12.tgz",
+          "integrity": "sha512-/xE6GvsKKqyo1BAY+KxOWXcLpPsUUyji7Qg3bVD7hh1eRze5bR1uYiuDA/k3Gof1s9BTzQZEJK8sNcNGFIzeWw==",
           "optional": true,
           "requires": {
             "body-parser": "^1.16.0",
@@ -77828,10 +80734,14 @@
           }
         },
         "set-immediate-shim": {
-          "version": "1.0.1"
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+          "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
         },
         "set-value": {
           "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+          "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
           "requires": {
             "extend-shallow": "^2.0.1",
             "is-extendable": "^0.1.1",
@@ -77841,24 +80751,34 @@
           "dependencies": {
             "extend-shallow": {
               "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
                 "is-extendable": "^0.1.0"
               }
             },
             "is-extendable": {
-              "version": "0.1.1"
+              "version": "0.1.1",
+              "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+              "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
             }
           }
         },
         "setimmediate": {
-          "version": "1.0.5"
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+          "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
         },
         "setprototypeof": {
           "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+          "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
           "optional": true
         },
         "sha.js": {
           "version": "2.4.11",
+          "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+          "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
           "requires": {
             "inherits": "^2.0.1",
             "safe-buffer": "^5.0.1"
@@ -77866,10 +80786,14 @@
         },
         "simple-concat": {
           "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+          "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
           "optional": true
         },
         "simple-get": {
           "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
+          "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
           "optional": true,
           "requires": {
             "decompress-response": "^3.3.0",
@@ -77879,6 +80803,8 @@
         },
         "snapdragon": {
           "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+          "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
           "requires": {
             "base": "^0.11.1",
             "debug": "^2.2.0",
@@ -77892,30 +80818,40 @@
           "dependencies": {
             "debug": {
               "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
               "requires": {
                 "ms": "2.0.0"
               }
             },
             "define-property": {
               "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "requires": {
                 "is-descriptor": "^0.1.0"
               }
             },
             "extend-shallow": {
               "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
                 "is-extendable": "^0.1.0"
               }
             },
             "is-accessor-descriptor": {
               "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+              "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
               "requires": {
                 "kind-of": "^3.0.2"
               },
               "dependencies": {
                 "kind-of": {
                   "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "requires": {
                     "is-buffer": "^1.1.5"
                   }
@@ -77923,16 +80859,22 @@
               }
             },
             "is-buffer": {
-              "version": "1.1.6"
+              "version": "1.1.6",
+              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+              "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
             },
             "is-data-descriptor": {
               "version": "0.1.4",
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+              "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
               "requires": {
                 "kind-of": "^3.0.2"
               },
               "dependencies": {
                 "kind-of": {
                   "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "requires": {
                     "is-buffer": "^1.1.5"
                   }
@@ -77941,6 +80883,8 @@
             },
             "is-descriptor": {
               "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "requires": {
                 "is-accessor-descriptor": "^0.1.6",
                 "is-data-descriptor": "^0.1.4",
@@ -77948,18 +80892,26 @@
               }
             },
             "is-extendable": {
-              "version": "0.1.1"
+              "version": "0.1.1",
+              "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+              "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
             },
             "kind-of": {
-              "version": "5.1.0"
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
             },
             "ms": {
-              "version": "2.0.0"
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
             }
           }
         },
         "snapdragon-node": {
           "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+          "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
           "requires": {
             "define-property": "^1.0.0",
             "isobject": "^3.0.0",
@@ -77968,6 +80920,8 @@
           "dependencies": {
             "define-property": {
               "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "requires": {
                 "is-descriptor": "^1.0.0"
               }
@@ -77976,15 +80930,21 @@
         },
         "snapdragon-util": {
           "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+          "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
           "requires": {
             "kind-of": "^3.2.0"
           },
           "dependencies": {
             "is-buffer": {
-              "version": "1.1.6"
+              "version": "1.1.6",
+              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+              "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
             },
             "kind-of": {
               "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
                 "is-buffer": "^1.1.5"
               }
@@ -77992,10 +80952,14 @@
           }
         },
         "source-map": {
-          "version": "0.5.7"
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         },
         "source-map-resolve": {
           "version": "0.5.3",
+          "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
+          "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
           "requires": {
             "atob": "^2.1.2",
             "decode-uri-component": "^0.2.0",
@@ -78006,13 +80970,17 @@
         },
         "source-map-support": {
           "version": "0.5.12",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
+          "integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
           "requires": {
             "buffer-from": "^1.0.0",
             "source-map": "^0.6.0"
           },
           "dependencies": {
             "source-map": {
-              "version": "0.6.1"
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
             }
           }
         },
@@ -78021,12 +80989,16 @@
         },
         "split-string": {
           "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+          "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
           "requires": {
             "extend-shallow": "^3.0.0"
           }
         },
         "sshpk": {
           "version": "1.16.1",
+          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+          "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
           "requires": {
             "asn1": "~0.2.3",
             "assert-plus": "^1.0.0",
@@ -78040,12 +81012,16 @@
           },
           "dependencies": {
             "tweetnacl": {
-              "version": "0.14.5"
+              "version": "0.14.5",
+              "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+              "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
             }
           }
         },
         "static-extend": {
           "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+          "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
           "requires": {
             "define-property": "^0.2.5",
             "object-copy": "^0.1.0"
@@ -78053,18 +81029,24 @@
           "dependencies": {
             "define-property": {
               "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "requires": {
                 "is-descriptor": "^0.1.0"
               }
             },
             "is-accessor-descriptor": {
               "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+              "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
               "requires": {
                 "kind-of": "^3.0.2"
               },
               "dependencies": {
                 "kind-of": {
                   "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "requires": {
                     "is-buffer": "^1.1.5"
                   }
@@ -78072,16 +81054,22 @@
               }
             },
             "is-buffer": {
-              "version": "1.1.6"
+              "version": "1.1.6",
+              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+              "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
             },
             "is-data-descriptor": {
               "version": "0.1.4",
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+              "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
               "requires": {
                 "kind-of": "^3.0.2"
               },
               "dependencies": {
                 "kind-of": {
                   "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "requires": {
                     "is-buffer": "^1.1.5"
                   }
@@ -78090,6 +81078,8 @@
             },
             "is-descriptor": {
               "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "requires": {
                 "is-accessor-descriptor": "^0.1.6",
                 "is-data-descriptor": "^0.1.4",
@@ -78097,38 +81087,52 @@
               }
             },
             "kind-of": {
-              "version": "5.1.0"
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
             }
           }
         },
         "statuses": {
           "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+          "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
           "optional": true
         },
         "stream-to-pull-stream": {
           "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/stream-to-pull-stream/-/stream-to-pull-stream-1.7.3.tgz",
+          "integrity": "sha512-6sNyqJpr5dIOQdgNy/xcDWwDuzAsAwVzhzrWlAPAQ7Lkjx/rv0wgvxEyKwTq6FmNd5rjTrELt/CLmaSw7crMGg==",
           "requires": {
             "looper": "^3.0.0",
             "pull-stream": "^3.2.3"
           },
           "dependencies": {
             "looper": {
-              "version": "3.0.0"
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/looper/-/looper-3.0.0.tgz",
+              "integrity": "sha1-LvpUw7HLq6m5Su4uWRSwvlf7t0k="
             }
           }
         },
         "strict-uri-encode": {
           "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+          "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
           "optional": true
         },
         "string_decoder": {
           "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
             "safe-buffer": "~5.1.0"
           },
           "dependencies": {
             "safe-buffer": {
-              "version": "5.1.2"
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
             }
           }
         },
@@ -78156,18 +81160,24 @@
         },
         "strip-hex-prefix": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz",
+          "integrity": "sha1-DF8VX+8RUTczd96du1iNoFUA428=",
           "requires": {
             "is-hex-prefixed": "1.0.0"
           }
         },
         "supports-color": {
           "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "requires": {
             "has-flag": "^3.0.0"
           }
         },
         "swarm-js": {
           "version": "0.1.40",
+          "resolved": "https://registry.npmjs.org/swarm-js/-/swarm-js-0.1.40.tgz",
+          "integrity": "sha512-yqiOCEoA4/IShXkY3WKwP5PvZhmoOOD8clsKA7EEcRILMkTEYHCQ21HDCAcVpmIxZq4LyZvWeRJ6quIyHk1caA==",
           "optional": true,
           "requires": {
             "bluebird": "^3.5.0",
@@ -78185,6 +81195,8 @@
           "dependencies": {
             "fs-extra": {
               "version": "4.0.3",
+              "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+              "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
               "optional": true,
               "requires": {
                 "graceful-fs": "^4.1.2",
@@ -78194,10 +81206,14 @@
             },
             "get-stream": {
               "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+              "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
               "optional": true
             },
             "got": {
               "version": "7.1.0",
+              "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
+              "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
               "optional": true,
               "requires": {
                 "decompress-response": "^3.2.0",
@@ -78218,18 +81234,26 @@
             },
             "is-stream": {
               "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+              "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
               "optional": true
             },
             "p-cancelable": {
               "version": "0.3.0",
+              "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
+              "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw==",
               "optional": true
             },
             "prepend-http": {
               "version": "1.0.4",
+              "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+              "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
               "optional": true
             },
             "url-parse-lax": {
               "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+              "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
               "optional": true,
               "requires": {
                 "prepend-http": "^1.0.1"
@@ -78307,6 +81331,8 @@
             },
             "minipass": {
               "version": "2.9.0",
+              "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+              "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
               "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
@@ -78316,10 +81342,14 @@
           }
         },
         "through": {
-          "version": "2.3.8"
+          "version": "2.3.8",
+          "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+          "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
         },
         "through2": {
           "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
           "requires": {
             "readable-stream": "~2.3.6",
             "xtend": "~4.0.1"
@@ -78327,25 +81357,35 @@
         },
         "timed-out": {
           "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+          "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
           "optional": true
         },
         "tmp": {
           "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
+          "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
           "requires": {
             "rimraf": "^2.6.3"
           }
         },
         "to-object-path": {
           "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+          "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
           "requires": {
             "kind-of": "^3.0.2"
           },
           "dependencies": {
             "is-buffer": {
-              "version": "1.1.6"
+              "version": "1.1.6",
+              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+              "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
             },
             "kind-of": {
               "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
                 "is-buffer": "^1.1.5"
               }
@@ -78354,10 +81394,14 @@
         },
         "to-readable-stream": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
+          "integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==",
           "optional": true
         },
         "to-regex": {
           "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+          "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
           "requires": {
             "define-property": "^2.0.2",
             "extend-shallow": "^3.0.2",
@@ -78367,35 +81411,51 @@
         },
         "toidentifier": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+          "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
           "optional": true
         },
         "tough-cookie": {
           "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+          "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
           "requires": {
             "psl": "^1.1.28",
             "punycode": "^2.1.1"
           }
         },
         "trim-right": {
-          "version": "1.0.1"
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+          "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
         },
         "tunnel-agent": {
           "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
           "requires": {
             "safe-buffer": "^5.0.1"
           }
         },
         "tweetnacl": {
-          "version": "1.0.3"
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+          "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
         },
         "tweetnacl-util": {
-          "version": "0.15.1"
+          "version": "0.15.1",
+          "resolved": "https://registry.npmjs.org/tweetnacl-util/-/tweetnacl-util-0.15.1.tgz",
+          "integrity": "sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw=="
         },
         "type": {
-          "version": "1.2.0"
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+          "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
         },
         "type-is": {
           "version": "1.6.18",
+          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+          "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
           "optional": true,
           "requires": {
             "media-typer": "0.3.0",
@@ -78403,36 +81463,52 @@
           }
         },
         "typedarray": {
-          "version": "0.0.6"
+          "version": "0.0.6",
+          "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+          "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
         },
         "typedarray-to-buffer": {
           "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+          "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
           "requires": {
             "is-typedarray": "^1.0.0"
           }
         },
         "typewise": {
           "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/typewise/-/typewise-1.0.3.tgz",
+          "integrity": "sha1-EGeTZUCvl5N8xdz5kiSG6fooRlE=",
           "requires": {
             "typewise-core": "^1.2.0"
           }
         },
         "typewise-core": {
-          "version": "1.2.0"
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/typewise-core/-/typewise-core-1.2.0.tgz",
+          "integrity": "sha1-l+uRgFx/VdL5QXSPpQ0xXZke8ZU="
         },
         "typewiselite": {
-          "version": "1.0.0"
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/typewiselite/-/typewiselite-1.0.0.tgz",
+          "integrity": "sha1-yIgvobsQksBgBal/NO9chQjjZk4="
         },
         "ultron": {
           "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
+          "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
           "optional": true
         },
         "underscore": {
           "version": "1.9.1",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
+          "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==",
           "optional": true
         },
         "union-value": {
           "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+          "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
           "requires": {
             "arr-union": "^3.1.0",
             "get-value": "^2.0.6",
@@ -78441,22 +81517,32 @@
           },
           "dependencies": {
             "is-extendable": {
-              "version": "0.1.1"
+              "version": "0.1.1",
+              "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+              "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
             }
           }
         },
         "universalify": {
-          "version": "0.1.2"
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
         },
         "unorm": {
-          "version": "1.6.0"
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/unorm/-/unorm-1.6.0.tgz",
+          "integrity": "sha512-b2/KCUlYZUeA7JFUuRJZPUtr4gZvBh7tavtv4fvk4+KV9pfGiR6CQAQAWl49ZpR3ts2dk4FYkP7EIgDJoiOLDA=="
         },
         "unpipe": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+          "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
           "optional": true
         },
         "unset-value": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+          "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
           "requires": {
             "has-value": "^0.3.1",
             "isobject": "^3.0.0"
@@ -78464,6 +81550,8 @@
           "dependencies": {
             "has-value": {
               "version": "0.3.1",
+              "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+              "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
               "requires": {
                 "get-value": "^2.0.3",
                 "has-values": "^0.1.4",
@@ -78472,6 +81560,8 @@
               "dependencies": {
                 "isobject": {
                   "version": "2.1.0",
+                  "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+                  "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
                   "requires": {
                     "isarray": "1.0.0"
                   }
@@ -78479,21 +81569,29 @@
               }
             },
             "has-values": {
-              "version": "0.1.4"
+              "version": "0.1.4",
+              "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+              "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
             }
           }
         },
         "uri-js": {
           "version": "4.4.1",
+          "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+          "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
           "requires": {
             "punycode": "^2.1.0"
           }
         },
         "urix": {
-          "version": "0.1.0"
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+          "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
         },
         "url-parse-lax": {
           "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+          "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
           "optional": true,
           "requires": {
             "prepend-http": "^2.0.0"
@@ -78501,14 +81599,20 @@
         },
         "url-set-query": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/url-set-query/-/url-set-query-1.0.0.tgz",
+          "integrity": "sha1-AW6M/Xwg7gXK/neV6JK9BwL6ozk=",
           "optional": true
         },
         "url-to-options": {
           "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
+          "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k=",
           "optional": true
         },
         "use": {
-          "version": "3.1.1"
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+          "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
         },
         "utf-8-validate": {
           "version": "5.0.4",
@@ -78518,10 +81622,14 @@
         },
         "utf8": {
           "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
+          "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ==",
           "optional": true
         },
         "util-deprecate": {
-          "version": "1.0.2"
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
         },
         "util.promisify": {
           "version": "1.1.1",
@@ -78535,21 +81643,31 @@
         },
         "utils-merge": {
           "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+          "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
           "optional": true
         },
         "uuid": {
-          "version": "3.4.0"
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
         },
         "varint": {
           "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
+          "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow==",
           "optional": true
         },
         "vary": {
           "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+          "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
           "optional": true
         },
         "verror": {
           "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+          "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
           "requires": {
             "assert-plus": "^1.0.0",
             "core-util-is": "1.0.2",
@@ -78558,6 +81676,8 @@
         },
         "web3": {
           "version": "1.2.11",
+          "resolved": "https://registry.npmjs.org/web3/-/web3-1.2.11.tgz",
+          "integrity": "sha512-mjQ8HeU41G6hgOYm1pmeH0mRAeNKJGnJEUzDMoerkpw7QUQT4exVREgF1MYPvL/z6vAshOXei25LE/t/Bxl8yQ==",
           "optional": true,
           "requires": {
             "web3-bzz": "1.2.11",
@@ -78571,6 +81691,8 @@
         },
         "web3-bzz": {
           "version": "1.2.11",
+          "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.2.11.tgz",
+          "integrity": "sha512-XGpWUEElGypBjeFyUhTkiPXFbDVD6Nr/S5jznE3t8cWUA0FxRf1n3n/NuIZeb0H9RkN2Ctd/jNma/k8XGa3YKg==",
           "optional": true,
           "requires": {
             "@types/node": "^12.12.6",
@@ -78587,6 +81709,8 @@
         },
         "web3-core": {
           "version": "1.2.11",
+          "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.2.11.tgz",
+          "integrity": "sha512-CN7MEYOY5ryo5iVleIWRE3a3cZqVaLlIbIzDPsvQRUfzYnvzZQRZBm9Mq+ttDi2STOOzc1MKylspz/o3yq/LjQ==",
           "optional": true,
           "requires": {
             "@types/bn.js": "^4.11.5",
@@ -78606,6 +81730,8 @@
         },
         "web3-core-helpers": {
           "version": "1.2.11",
+          "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.11.tgz",
+          "integrity": "sha512-PEPoAoZd5ME7UfbnCZBdzIerpe74GEvlwT4AjOmHeCVZoIFk7EqvOZDejJHt+feJA6kMVTdd0xzRNN295UhC1A==",
           "optional": true,
           "requires": {
             "underscore": "1.9.1",
@@ -78615,6 +81741,8 @@
         },
         "web3-core-method": {
           "version": "1.2.11",
+          "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.2.11.tgz",
+          "integrity": "sha512-ff0q76Cde94HAxLDZ6DbdmKniYCQVtvuaYh+rtOUMB6kssa5FX0q3vPmixi7NPooFnbKmmZCM6NvXg4IreTPIw==",
           "optional": true,
           "requires": {
             "@ethersproject/transactions": "^5.0.0-beta.135",
@@ -78627,6 +81755,8 @@
         },
         "web3-core-promievent": {
           "version": "1.2.11",
+          "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.2.11.tgz",
+          "integrity": "sha512-il4McoDa/Ox9Agh4kyfQ8Ak/9ABYpnF8poBLL33R/EnxLsJOGQG2nZhkJa3I067hocrPSjEdlPt/0bHXsln4qA==",
           "optional": true,
           "requires": {
             "eventemitter3": "4.0.4"
@@ -78634,6 +81764,8 @@
         },
         "web3-core-requestmanager": {
           "version": "1.2.11",
+          "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.2.11.tgz",
+          "integrity": "sha512-oFhBtLfOiIbmfl6T6gYjjj9igOvtyxJ+fjS+byRxiwFJyJ5BQOz4/9/17gWR1Cq74paTlI7vDGxYfuvfE/mKvA==",
           "optional": true,
           "requires": {
             "underscore": "1.9.1",
@@ -78645,6 +81777,8 @@
         },
         "web3-core-subscriptions": {
           "version": "1.2.11",
+          "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.2.11.tgz",
+          "integrity": "sha512-qEF/OVqkCvQ7MPs1JylIZCZkin0aKK9lDxpAtQ1F8niEDGFqn7DT8E/vzbIa0GsOjL2fZjDhWJsaW+BSoAW1gg==",
           "optional": true,
           "requires": {
             "eventemitter3": "4.0.4",
@@ -78654,6 +81788,8 @@
         },
         "web3-eth": {
           "version": "1.2.11",
+          "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.2.11.tgz",
+          "integrity": "sha512-REvxW1wJ58AgHPcXPJOL49d1K/dPmuw4LjPLBPStOVkQjzDTVmJEIsiLwn2YeuNDd4pfakBwT8L3bz1G1/wVsQ==",
           "optional": true,
           "requires": {
             "underscore": "1.9.1",
@@ -78673,6 +81809,8 @@
         },
         "web3-eth-abi": {
           "version": "1.2.11",
+          "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.2.11.tgz",
+          "integrity": "sha512-PkRYc0+MjuLSgg03QVWqWlQivJqRwKItKtEpRUaxUAeLE7i/uU39gmzm2keHGcQXo3POXAbOnMqkDvOep89Crg==",
           "optional": true,
           "requires": {
             "@ethersproject/abi": "5.0.0-beta.153",
@@ -78682,6 +81820,8 @@
         },
         "web3-eth-accounts": {
           "version": "1.2.11",
+          "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.2.11.tgz",
+          "integrity": "sha512-6FwPqEpCfKIh3nSSGeo3uBm2iFSnFJDfwL3oS9pyegRBXNsGRVpgiW63yhNzL0796StsvjHWwQnQHsZNxWAkGw==",
           "optional": true,
           "requires": {
             "crypto-browserify": "3.12.0",
@@ -78699,6 +81839,8 @@
           "dependencies": {
             "eth-lib": {
               "version": "0.2.8",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+              "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
               "optional": true,
               "requires": {
                 "bn.js": "^4.11.6",
@@ -78708,12 +81850,16 @@
             },
             "uuid": {
               "version": "3.3.2",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+              "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
               "optional": true
             }
           }
         },
         "web3-eth-contract": {
           "version": "1.2.11",
+          "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.2.11.tgz",
+          "integrity": "sha512-MzYuI/Rq2o6gn7vCGcnQgco63isPNK5lMAan2E51AJLknjSLnOxwNY3gM8BcKoy4Z+v5Dv00a03Xuk78JowFow==",
           "optional": true,
           "requires": {
             "@types/bn.js": "^4.11.5",
@@ -78729,6 +81875,8 @@
         },
         "web3-eth-ens": {
           "version": "1.2.11",
+          "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.2.11.tgz",
+          "integrity": "sha512-dbW7dXP6HqT1EAPvnniZVnmw6TmQEKF6/1KgAxbo8iBBYrVTMDGFQUUnZ+C4VETGrwwaqtX4L9d/FrQhZ6SUiA==",
           "optional": true,
           "requires": {
             "content-hash": "^2.5.2",
@@ -78744,6 +81892,8 @@
         },
         "web3-eth-iban": {
           "version": "1.2.11",
+          "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.2.11.tgz",
+          "integrity": "sha512-ozuVlZ5jwFC2hJY4+fH9pIcuH1xP0HEFhtWsR69u9uDIANHLPQQtWYmdj7xQ3p2YT4bQLq/axKhZi7EZVetmxQ==",
           "optional": true,
           "requires": {
             "bn.js": "^4.11.9",
@@ -78752,6 +81902,8 @@
         },
         "web3-eth-personal": {
           "version": "1.2.11",
+          "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.2.11.tgz",
+          "integrity": "sha512-42IzUtKq9iHZ8K9VN0vAI50iSU9tOA1V7XU2BhF/tb7We2iKBVdkley2fg26TxlOcKNEHm7o6HRtiiFsVK4Ifw==",
           "optional": true,
           "requires": {
             "@types/node": "^12.12.6",
@@ -78770,6 +81922,8 @@
         },
         "web3-net": {
           "version": "1.2.11",
+          "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.2.11.tgz",
+          "integrity": "sha512-sjrSDj0pTfZouR5BSTItCuZ5K/oZPVdVciPQ6981PPPIwJJkCMeVjD7I4zO3qDPCnBjBSbWvVnLdwqUBPtHxyg==",
           "optional": true,
           "requires": {
             "web3-core": "1.2.11",
@@ -78779,6 +81933,8 @@
         },
         "web3-provider-engine": {
           "version": "14.2.1",
+          "resolved": "https://registry.npmjs.org/web3-provider-engine/-/web3-provider-engine-14.2.1.tgz",
+          "integrity": "sha512-iSv31h2qXkr9vrL6UZDm4leZMc32SjWJFGOp/D92JXfcEboCqraZyuExDkpxKw8ziTufXieNM7LSXNHzszYdJw==",
           "requires": {
             "async": "^2.5.0",
             "backoff": "^2.5.0",
@@ -78804,12 +81960,16 @@
           "dependencies": {
             "abstract-leveldown": {
               "version": "2.6.3",
+              "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
+              "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
               "requires": {
                 "xtend": "~4.0.0"
               }
             },
             "deferred-leveldown": {
               "version": "1.2.2",
+              "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz",
+              "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
               "requires": {
                 "abstract-leveldown": "~2.6.0"
               }
@@ -78823,6 +81983,8 @@
             },
             "ethereumjs-account": {
               "version": "2.0.5",
+              "resolved": "https://registry.npmjs.org/ethereumjs-account/-/ethereumjs-account-2.0.5.tgz",
+              "integrity": "sha512-bgDojnXGjhMwo6eXQC0bY6UK2liSFUSMwwylOmQvZbSl/D7NXQ3+vrGO46ZeOgjGfxXmgIeVNDIiHw7fNZM4VA==",
               "requires": {
                 "ethereumjs-util": "^5.0.0",
                 "rlp": "^2.0.0",
@@ -78831,6 +81993,8 @@
             },
             "ethereumjs-block": {
               "version": "1.7.1",
+              "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.7.1.tgz",
+              "integrity": "sha512-B+sSdtqm78fmKkBq78/QLKJbu/4Ts4P2KFISdgcuZUPDm9x+N7qgBPIIFUGbaakQh8bzuquiRVbdmvPKqbILRg==",
               "requires": {
                 "async": "^2.0.1",
                 "ethereum-common": "0.2.0",
@@ -78840,12 +82004,16 @@
               },
               "dependencies": {
                 "ethereum-common": {
-                  "version": "0.2.0"
+                  "version": "0.2.0",
+                  "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.2.0.tgz",
+                  "integrity": "sha512-XOnAR/3rntJgbCdGhqdaLIxDLWKLmsZOGhHdBKadEr6gEnJLH52k93Ou+TUdFaPN3hJc3isBZBal3U/XZ15abA=="
                 }
               }
             },
             "ethereumjs-tx": {
               "version": "1.3.7",
+              "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-1.3.7.tgz",
+              "integrity": "sha512-wvLMxzt1RPhAQ9Yi3/HKZTn0FZYpnsmQdbKYfUUpi4j1SEIcbkd9tndVjcPrufY3V7j2IebOpC00Zp2P/Ay2kA==",
               "requires": {
                 "ethereum-common": "^0.0.18",
                 "ethereumjs-util": "^5.0.0"
@@ -78853,6 +82021,8 @@
             },
             "ethereumjs-util": {
               "version": "5.2.1",
+              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+              "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
               "requires": {
                 "bn.js": "^4.11.0",
                 "create-hash": "^1.1.2",
@@ -78865,6 +82035,8 @@
             },
             "ethereumjs-vm": {
               "version": "2.6.0",
+              "resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-2.6.0.tgz",
+              "integrity": "sha512-r/XIUik/ynGbxS3y+mvGnbOKnuLo40V5Mj1J25+HEO63aWYREIqvWeRO/hnROlMBE5WoniQmPmhiaN0ctiHaXw==",
               "requires": {
                 "async": "^2.1.2",
                 "async-eventemitter": "^0.2.2",
@@ -78881,6 +82053,8 @@
               "dependencies": {
                 "ethereumjs-block": {
                   "version": "2.2.2",
+                  "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-2.2.2.tgz",
+                  "integrity": "sha512-2p49ifhek3h2zeg/+da6XpdFR3GlqY3BIEiqxGF8j9aSRIgkb7M1Ky+yULBKJOu8PAZxfhsYA+HxUk2aCQp3vg==",
                   "requires": {
                     "async": "^2.0.1",
                     "ethereumjs-common": "^1.5.0",
@@ -78891,6 +82065,8 @@
                   "dependencies": {
                     "ethereumjs-util": {
                       "version": "5.2.1",
+                      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+                      "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
                       "requires": {
                         "bn.js": "^4.11.0",
                         "create-hash": "^1.1.2",
@@ -78905,6 +82081,8 @@
                 },
                 "ethereumjs-tx": {
                   "version": "2.1.2",
+                  "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-2.1.2.tgz",
+                  "integrity": "sha512-zZEK1onCeiORb0wyCXUvg94Ve5It/K6GD1K+26KfFKodiBiS6d9lfCXlUKGBBdQ+bv7Day+JK0tj1K+BeNFRAw==",
                   "requires": {
                     "ethereumjs-common": "^1.5.0",
                     "ethereumjs-util": "^6.0.0"
@@ -78912,6 +82090,8 @@
                 },
                 "ethereumjs-util": {
                   "version": "6.2.1",
+                  "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
+                  "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
                   "requires": {
                     "@types/bn.js": "^4.11.3",
                     "bn.js": "^4.11.0",
@@ -78925,19 +82105,27 @@
               }
             },
             "isarray": {
-              "version": "0.0.1"
+              "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
             },
             "level-codec": {
-              "version": "7.0.1"
+              "version": "7.0.1",
+              "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-7.0.1.tgz",
+              "integrity": "sha512-Ua/R9B9r3RasXdRmOtd+t9TCOEIIlts+TN/7XTT2unhDaL6sJn83S3rUyljbr6lVtw49N3/yA0HHjpV6Kzb2aQ=="
             },
             "level-errors": {
               "version": "1.0.5",
+              "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.5.tgz",
+              "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
               "requires": {
                 "errno": "~0.1.1"
               }
             },
             "level-iterator-stream": {
               "version": "1.3.1",
+              "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
+              "integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
               "requires": {
                 "inherits": "^2.0.1",
                 "level-errors": "^1.0.3",
@@ -78947,6 +82135,8 @@
               "dependencies": {
                 "readable-stream": {
                   "version": "1.1.14",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+                  "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
                   "requires": {
                     "core-util-is": "~1.0.0",
                     "inherits": "~2.0.1",
@@ -78958,6 +82148,8 @@
             },
             "level-ws": {
               "version": "0.0.0",
+              "resolved": "https://registry.npmjs.org/level-ws/-/level-ws-0.0.0.tgz",
+              "integrity": "sha1-Ny5RIXeSSgBCSwtDrvK7QkltIos=",
               "requires": {
                 "readable-stream": "~1.0.15",
                 "xtend": "~2.1.1"
@@ -78965,6 +82157,8 @@
               "dependencies": {
                 "readable-stream": {
                   "version": "1.0.34",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                  "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                   "requires": {
                     "core-util-is": "~1.0.0",
                     "inherits": "~2.0.1",
@@ -78974,6 +82168,8 @@
                 },
                 "xtend": {
                   "version": "2.1.2",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+                  "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
                   "requires": {
                     "object-keys": "~0.4.0"
                   }
@@ -78982,6 +82178,8 @@
             },
             "levelup": {
               "version": "1.3.9",
+              "resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.9.tgz",
+              "integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
               "requires": {
                 "deferred-leveldown": "~1.2.1",
                 "level-codec": "~7.0.0",
@@ -78993,10 +82191,14 @@
               }
             },
             "ltgt": {
-              "version": "2.2.1"
+              "version": "2.2.1",
+              "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
+              "integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU="
             },
             "memdown": {
               "version": "1.4.1",
+              "resolved": "https://registry.npmjs.org/memdown/-/memdown-1.4.1.tgz",
+              "integrity": "sha1-tOThkhdGZP+65BNhqlAPMRnv4hU=",
               "requires": {
                 "abstract-leveldown": "~2.7.1",
                 "functional-red-black-tree": "^1.0.1",
@@ -79008,6 +82210,8 @@
               "dependencies": {
                 "abstract-leveldown": {
                   "version": "2.7.2",
+                  "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
+                  "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
                   "requires": {
                     "xtend": "~4.0.0"
                   }
@@ -79016,6 +82220,8 @@
             },
             "merkle-patricia-tree": {
               "version": "2.3.2",
+              "resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-2.3.2.tgz",
+              "integrity": "sha512-81PW5m8oz/pz3GvsAwbauj7Y00rqm81Tzad77tHBwU7pIAtN+TJnMSOJhxBKflSVYhptMMb9RskhqHqrSm1V+g==",
               "requires": {
                 "async": "^1.4.2",
                 "ethereumjs-util": "^5.0.0",
@@ -79028,21 +82234,31 @@
               },
               "dependencies": {
                 "async": {
-                  "version": "1.5.2"
+                  "version": "1.5.2",
+                  "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+                  "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
                 }
               }
             },
             "object-keys": {
-              "version": "0.4.0"
+              "version": "0.4.0",
+              "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+              "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY="
             },
             "safe-buffer": {
-              "version": "5.1.2"
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
             },
             "semver": {
-              "version": "5.4.1"
+              "version": "5.4.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+              "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
             },
             "string_decoder": {
-              "version": "0.10.31"
+              "version": "0.10.31",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
             },
             "ws": {
               "version": "5.2.2",
@@ -79054,6 +82270,8 @@
         },
         "web3-providers-http": {
           "version": "1.2.11",
+          "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.2.11.tgz",
+          "integrity": "sha512-psh4hYGb1+ijWywfwpB2cvvOIMISlR44F/rJtYkRmQ5jMvG4FOCPlQJPiHQZo+2cc3HbktvvSJzIhkWQJdmvrA==",
           "optional": true,
           "requires": {
             "web3-core-helpers": "1.2.11",
@@ -79062,6 +82280,8 @@
         },
         "web3-providers-ipc": {
           "version": "1.2.11",
+          "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.2.11.tgz",
+          "integrity": "sha512-yhc7Y/k8hBV/KlELxynWjJDzmgDEDjIjBzXK+e0rHBsYEhdCNdIH5Psa456c+l0qTEU2YzycF8VAjYpWfPnBpQ==",
           "optional": true,
           "requires": {
             "oboe": "2.1.4",
@@ -79071,6 +82291,8 @@
         },
         "web3-providers-ws": {
           "version": "1.2.11",
+          "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.2.11.tgz",
+          "integrity": "sha512-ZxnjIY1Er8Ty+cE4migzr43zA/+72AF1myzsLaU5eVgdsfV7Jqx7Dix1hbevNZDKFlSoEyq/3j/jYalh3So1Zg==",
           "optional": true,
           "requires": {
             "eventemitter3": "4.0.4",
@@ -79081,6 +82303,8 @@
         },
         "web3-shh": {
           "version": "1.2.11",
+          "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.2.11.tgz",
+          "integrity": "sha512-B3OrO3oG1L+bv3E1sTwCx66injW1A8hhwpknDUbV+sw3fehFazA06z9SGXUefuFI1kVs4q2vRi0n4oCcI4dZDg==",
           "optional": true,
           "requires": {
             "web3-core": "1.2.11",
@@ -79091,6 +82315,8 @@
         },
         "web3-utils": {
           "version": "1.2.11",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.11.tgz",
+          "integrity": "sha512-3Tq09izhD+ThqHEaWYX4VOT7dNPdZiO+c/1QMA0s5X2lDFKK/xHJb7cyTRRVzN2LvlHbR7baS1tmQhSua51TcQ==",
           "optional": true,
           "requires": {
             "bn.js": "^4.11.9",
@@ -79105,6 +82331,8 @@
           "dependencies": {
             "eth-lib": {
               "version": "0.2.8",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+              "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
               "optional": true,
               "requires": {
                 "bn.js": "^4.11.6",
@@ -79116,6 +82344,8 @@
         },
         "websocket": {
           "version": "1.0.32",
+          "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.32.tgz",
+          "integrity": "sha512-i4yhcllSP4wrpoPMU2N0TQ/q0O94LRG/eUQjEAamRltjQ1oT1PFFKOG4i877OlJgCG8rw6LrrowJp+TYCEWF7Q==",
           "requires": {
             "bufferutil": "^4.0.1",
             "debug": "^2.2.0",
@@ -79127,23 +82357,33 @@
           "dependencies": {
             "debug": {
               "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
               "requires": {
                 "ms": "2.0.0"
               }
             },
             "ms": {
-              "version": "2.0.0"
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
             }
           }
         },
         "whatwg-fetch": {
-          "version": "2.0.4"
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+          "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
         },
         "wrappy": {
-          "version": "1.0.2"
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "ws": {
           "version": "3.3.3",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
+          "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
           "optional": true,
           "requires": {
             "async-limiter": "~1.0.0",
@@ -79153,12 +82393,16 @@
           "dependencies": {
             "safe-buffer": {
               "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
               "optional": true
             }
           }
         },
         "xhr": {
           "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.6.0.tgz",
+          "integrity": "sha512-/eCGLb5rxjx5e3mF1A7s+pLlR6CGyqWN91fv1JgER5mVWg1MZmlhBvy9kjcsOdRk8RrIujotWyJamfyrp+WIcA==",
           "requires": {
             "global": "~4.4.0",
             "is-function": "^1.0.1",
@@ -79168,6 +82412,8 @@
         },
         "xhr-request": {
           "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/xhr-request/-/xhr-request-1.1.0.tgz",
+          "integrity": "sha512-Y7qzEaR3FDtL3fP30k9wO/e+FBnBByZeybKOhASsGP30NIkRAAkKD/sCnLvgEfAIEC1rcmK7YG8f4oEnIrrWzA==",
           "optional": true,
           "requires": {
             "buffer-to-arraybuffer": "^0.0.5",
@@ -79181,6 +82427,8 @@
         },
         "xhr-request-promise": {
           "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/xhr-request-promise/-/xhr-request-promise-0.1.3.tgz",
+          "integrity": "sha512-YUBytBsuwgitWtdRzXDDkWAXzhdGB8bYm0sSzMPZT7Z2MBjMSTHFsyCT1yCRATY+XC69DUrQraRAEgcoCRaIPg==",
           "optional": true,
           "requires": {
             "xhr-request": "^1.1.0"
@@ -79188,19 +82436,27 @@
         },
         "xhr2-cookies": {
           "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/xhr2-cookies/-/xhr2-cookies-1.1.0.tgz",
+          "integrity": "sha1-fXdEnQmZGX8VXLc7I99yUF7YnUg=",
           "optional": true,
           "requires": {
             "cookiejar": "^2.1.1"
           }
         },
         "xtend": {
-          "version": "4.0.2"
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+          "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
         },
         "yaeti": {
-          "version": "0.0.6"
+          "version": "0.0.6",
+          "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
+          "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc="
         },
         "yallist": {
-          "version": "3.1.1"
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@web3-react/injected-connector": "^6.0.7",
     "@web3-react/portis-connector": "^6.1.9",
     "@web3-react/torus-connector": "^6.1.9",
-    "@web3-react/walletlink-connector": "^6.2.8",
+    "@web3-react/walletlink-connector": "^6.2.11",
     "classnames": "^2.3.1",
     "d3-array": "^3.1.1",
     "dayjs": "^1.10.7",

--- a/src/components/TxConfirmationView/NetworkMismatch/index.tsx
+++ b/src/components/TxConfirmationView/NetworkMismatch/index.tsx
@@ -80,7 +80,8 @@ export default function NetworkMismatch({
 
   const config = ADD_CONFIG[neededChainId];
   const isMetaMask = (global.window as any)?.ethereum?.isMetaMask;
-  const isCoinbaseWallet = (global.window as any)?.ethereum?.isCoinbaseWallet;
+  // @ts-ignore
+  const isCoinbaseWallet = library?.provider?.isCoinbaseWallet === true;
   const isAddable =
     (isMetaMask || isCoinbaseWallet) &&
     ['browser', 'wallet-link'].includes(currentProviderName) &&

--- a/src/components/TxConfirmationView/NetworkMismatch/index.tsx
+++ b/src/components/TxConfirmationView/NetworkMismatch/index.tsx
@@ -79,8 +79,10 @@ export default function NetworkMismatch({
   const { handleNetworkChange } = useUserWalletDataContext();
 
   const config = ADD_CONFIG[neededChainId];
+  const isMetaMask = (global.window as any)?.ethereum?.isMetaMask;
+  const isCoinbaseWallet = (global.window as any)?.ethereum?.isCoinbaseWallet;
   const isAddable =
-    (global.window as any)?.ethereum?.isMetaMask &&
+    (isMetaMask || isCoinbaseWallet) &&
     ['browser', 'wallet-link'].includes(currentProviderName) &&
     config;
   const { publicJsonRPCWSUrl, publicJsonRPCUrl } = getNetworkConfig(neededChainId);


### PR DESCRIPTION
All the Coinbase Wallet clients have support for `wallet_addEthereumChain` and `wallet_switchEthereumChain` requests. This is just a small change to enable sending those requests to CB Wallet clients.